### PR TITLE
feat: make router type safe, closes #54

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -14,7 +14,7 @@ import {
 } from "@ionic/react";
 import { IonReactRouter } from "@ionic/react-router";
 import { pencil, cog, notifications, people, home } from "ionicons/icons";
-import { Route, Redirect, Link } from "react-router-dom";
+import { Route, Link, Redirect } from "@/src/components/nav/index";
 import _ from "lodash";
 import { twMerge } from "tailwind-merge";
 import { useMedia } from "@/src/lib/hooks";
@@ -95,9 +95,9 @@ const CREATE_POST_STACK = [
 const COMMUNITIES_STACK = [
   <Route path="/communities/*" component={NotFound} />,
   <Route
-    key="/communities/"
+    key="/communities"
     exact
-    path="/communities/"
+    path="/communities"
     component={CommunitiesFeed}
   />,
   <Route key="/communities/s" exact path="/communities/s">

--- a/src/components/auth-context.tsx
+++ b/src/components/auth-context.tsx
@@ -31,8 +31,6 @@ import {
   InputOTPSlot,
 } from "./ui/input-otp";
 import { LuLoaderCircle } from "react-icons/lu";
-import { Link } from "react-router-dom";
-import * as routes from "@/src/lib/routes";
 
 const Context = createContext<{
   authenticate: (config?: { addAccount?: boolean }) => Promise<void>;

--- a/src/components/communities/community-card.tsx
+++ b/src/components/communities/community-card.tsx
@@ -2,7 +2,7 @@ import { CommunityAggregates, CommunityView } from "lemmy-js-client";
 import { abbriviateNumber } from "@/src/lib/format";
 import { createSlug, Slug } from "@/src/lib/lemmy/utils";
 import { useLinkContext } from "@/src/components/nav/link-context";
-import { Link } from "react-router-dom";
+import { Link } from "@/src/components/nav/index";
 import {
   Avatar,
   AvatarFallback,

--- a/src/components/communities/community-sidebar.tsx
+++ b/src/components/communities/community-sidebar.tsx
@@ -7,7 +7,7 @@ import { CommunityJoinButton } from "./community-join-button";
 import { useLinkContext } from "../nav/link-context";
 import { useCommunitiesStore } from "@/src/stores/communities";
 import { LuCakeSlice } from "react-icons/lu";
-import { Link } from "react-router-dom";
+import { Link } from "@/src/components/nav/index";
 import { cn } from "@/src/lib/utils";
 import { Skeleton } from "../ui/skeleton";
 import { useAuth } from "@/src/stores/auth";
@@ -23,6 +23,7 @@ import {
   AvatarImage,
 } from "@/src/components/ui/avatar";
 import { PersonCard } from "../person/person-card";
+import { shareRoute } from "@/src/lib/share";
 
 dayjs.extend(localizedFormat);
 
@@ -69,8 +70,8 @@ export function CommunitySidebar({
       {
         text: "Share",
         onClick: () =>
-          Share.share({
-            url: `https://blorpblorp.xyz${linkCtx.root}c/${communityName}`,
+          shareRoute({
+            route: `${linkCtx.root}c/${communityName}`,
           }),
       },
       ...(actorId
@@ -230,8 +231,8 @@ export function SmallScreenSidebar({
       {
         text: "Share",
         onClick: () =>
-          Share.share({
-            url: `https://blorpblorp.xyz${linkCtx.root}c/${communityName}`,
+          shareRoute({
+            route: `${linkCtx.root}c/${communityName}`,
           }),
       },
       ...(actorId

--- a/src/components/markdown/renderer.tsx
+++ b/src/components/markdown/renderer.tsx
@@ -7,7 +7,7 @@ import parse, {
   domToReact,
   HTMLReactParserOptions,
 } from "html-react-parser";
-import { Link } from "react-router-dom";
+import { Link } from "@/src/components/nav/index";
 import { CodeBlock } from "./code-block";
 import { DetailedHTMLProps, ImgHTMLAttributes } from "react";
 import { useLongPress } from "use-long-press";
@@ -59,7 +59,7 @@ const options: (
       if (textContent && COMMUNITY_BANG.test(textContent)) {
         const href = `${root}c/${textContent.substring(1)}`;
         return (
-          <Link to={href}>
+          <Link to={href as never}>
             {domToReact(domNode.children as DOMNode[], options(root))}
           </Link>
         );
@@ -68,7 +68,7 @@ const options: (
       // Replace "/c/community" with "/selected-tab/c/community"
       if (/^\/c\/[^\/]+$/i.test(href)) {
         return (
-          <Link to={root + href.substring(1)}>
+          <Link to={(root + href.substring(1)) as never}>
             {domToReact(domNode.children as DOMNode[], options(root))}
           </Link>
         );
@@ -77,7 +77,7 @@ const options: (
       // Replace "/u/community" with "/selected-tab/u/community"
       if (/^\/u\/[^\/]+$/i.test(href)) {
         return (
-          <Link to={root + href.substring(1)}>
+          <Link to={(root + href.substring(1)) as never}>
             {domToReact(domNode.children as DOMNode[], options(root))}
           </Link>
         );
@@ -85,7 +85,7 @@ const options: (
 
       if (href.startsWith("/")) {
         return (
-          <Link to={href}>
+          <Link to={href as never}>
             {domToReact(domNode.children as DOMNode[], options(root))}
           </Link>
         );

--- a/src/components/nav.tsx
+++ b/src/components/nav.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router-dom";
+import { Link } from "@/src/components/nav/index";
 import {
   DropdownMenu,
   DropdownMenuContent,

--- a/src/components/nav/index.tsx
+++ b/src/components/nav/index.tsx
@@ -1,0 +1,58 @@
+import {
+  Link as DefaultLink,
+  LinkProps as DefaultLinkProps,
+  useParams as useParamsDefault,
+  useHistory as useHistoryDefault,
+  Route as RouteDefault,
+  RouteProps as RoutPropsDefault,
+  Redirect as RedirectDefault,
+  RedirectProps as RedirectPropsDefault,
+} from "react-router-dom";
+import z from "zod";
+import type {
+  Route as RouteType,
+  Redirect as RedirectType,
+  NotFound,
+} from "./routes.d";
+
+interface HistoryReturnValue
+  extends Omit<ReturnType<typeof useHistoryDefault>, "push"> {
+  push: (route: RouteType) => void;
+}
+
+export function useHistory(): HistoryReturnValue {
+  return useHistoryDefault();
+}
+
+export function useParams<Z extends z.ZodObject<any>>(schema: Z): z.infer<Z> {
+  const params = useParamsDefault();
+  return schema.parse(params);
+}
+
+export interface LinkProps extends Omit<DefaultLinkProps, "to"> {
+  searchParams?: `?${string}`;
+  to: RouteType;
+}
+
+export function Link({ searchParams, to, ...rest }: LinkProps) {
+  return <DefaultLink to={to + (searchParams ?? "")} {...rest} />;
+}
+
+interface RouteProps extends Omit<RoutPropsDefault, "path"> {
+  path?: RouteType<`:${string}`> | NotFound;
+}
+
+export function Route(props: RouteProps) {
+  return <RouteDefault {...props} />;
+}
+
+interface RedirectProps
+  extends Omit<RedirectPropsDefault, "to" | "path" | "from"> {
+  path?: RouteType<`:${string}`> | RedirectType<`:${string}`>;
+  from?: RouteType<`:${string}`> | RedirectType<`:${string}`>;
+  to: RouteType<`:${string}`>;
+}
+
+export function Redirect(props: RedirectProps) {
+  return <RedirectDefault {...props} />;
+}

--- a/src/components/nav/routes.d.tsx
+++ b/src/components/nav/routes.d.tsx
@@ -1,0 +1,26 @@
+type SimpleTab = "/create" | "/settings";
+type ComplexTab = "/home" | "/communities" | "/inbox";
+
+type ParimaryTabRoute<S extends string = string> =
+  | `/c/${S}`
+  | `/c/${S}/sidebar`
+  | `/c/${S}/s`
+  | `/c/${S}/posts/${S}`
+  | `/c/${S}/posts/${S}/comments/${S}`
+  | `/u/${S}`
+  | "/s"
+  | "/saved";
+
+export type Route<S extends string = string> =
+  | `/download`
+  | `/support`
+  | `/privacy`
+  | `/terms`
+  | `/csae`
+  | `${SimpleTab}`
+  | `${ComplexTab}`
+  | `${ComplexTab}${ParimaryTabRoute<S>}`;
+
+export type Redirect<S extends string = string> = "/" | `/c/${S}` | `/u/${S}`;
+
+export type NotFound = `${SimpleTab}/*` | `${ComplexTab}/*`;

--- a/src/components/person/person-card.tsx
+++ b/src/components/person/person-card.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router-dom";
+import { Link } from "@/src/components/nav/index";
 import {
   Avatar,
   AvatarFallback,

--- a/src/components/person/person-sidebar.tsx
+++ b/src/components/person/person-sidebar.tsx
@@ -22,6 +22,7 @@ import { useIonAlert } from "@ionic/react";
 import { useRequireAuth } from "../auth-context";
 import { useBlockPerson } from "@/src/lib/lemmy";
 import { getAccountActorId, useAuth } from "@/src/stores/auth";
+import { shareRoute } from "@/src/lib/share";
 
 dayjs.extend(localizedFormat);
 
@@ -55,8 +56,8 @@ export function PersonSidebar({
             {
               text: "Share",
               onClick: () =>
-                Share.share({
-                  url: `https://blorpblorp.xyz${linkCtx.root}u/${encodeApId(person?.actor_id)}`,
+                shareRoute({
+                  route: `${linkCtx.root}u/${encodeApId(person?.actor_id)}`,
                 }),
             },
             {

--- a/src/components/posts/post-buttons.tsx
+++ b/src/components/posts/post-buttons.tsx
@@ -2,7 +2,7 @@ import { useLikePost } from "@/src/lib/lemmy/index";
 import { voteHaptics } from "@/src/lib/voting";
 import { useRequireAuth } from "../auth-context";
 
-import { Link } from "react-router-dom";
+import { Link, LinkProps } from "@/src/components/nav/index";
 
 import {
   PiArrowFatUpBold,
@@ -93,7 +93,7 @@ export function PostCommentsButton({
   onClick,
 }: {
   commentsCount: number;
-  href?: string;
+  href?: LinkProps["to"];
   onClick?: () => void;
 }) {
   if (href) {

--- a/src/components/posts/post-byline.tsx
+++ b/src/components/posts/post-byline.tsx
@@ -10,7 +10,7 @@ import { useShowPostReportModal } from "./post-report";
 import { useAuth, getAccountActorId } from "@/src/stores/auth";
 import { openUrl } from "@/src/lib/linking";
 import { useMemo, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "@/src/components/nav/index";
 import { RelativeTime } from "../relative-time";
 import { ActionMenu, ActionMenuProps } from "../action-menu";
 import { IoEllipsisHorizontal } from "react-icons/io5";
@@ -31,6 +31,7 @@ import { Badge } from "@/src/components/ui/badge";
 import { postToDraft, useCreatePostStore } from "@/src/stores/create-post";
 import { usePostsStore } from "@/src/stores/posts";
 import { cn } from "@/src/lib/utils";
+import { shareRoute } from "@/src/lib/share";
 
 export function PostByline({
   id,
@@ -96,8 +97,8 @@ export function PostByline({
       {
         text: "Share",
         onClick: () =>
-          Share.share({
-            url: `https://blorpblorp.xyz${linkCtx.root}${communitySlug}/posts/${encodedApId}`,
+          shareRoute({
+            route: `${linkCtx.root}c/${communitySlug}/posts/${encodedApId}`,
           }),
       },
       {

--- a/src/components/posts/post-comment.tsx
+++ b/src/components/posts/post-comment.tsx
@@ -14,7 +14,7 @@ import { useRequireAuth } from "../auth-context";
 import { useLinkContext } from "../nav/link-context";
 import { Person } from "lemmy-js-client";
 import { createSlug, encodeApId } from "@/src/lib/lemmy/utils";
-import { Link } from "react-router-dom";
+import { Link } from "../nav/index";
 import {
   Avatar,
   AvatarFallback,
@@ -32,6 +32,7 @@ import { Badge } from "@/src/components/ui/badge";
 import { Button } from "../ui/button";
 import { useMemo } from "react";
 import { ContentGutters } from "../gutters";
+import { shareRoute } from "@/src/lib/share";
 
 function Byline({
   creator,
@@ -266,8 +267,8 @@ export function PostComment({
                 {
                   text: "Share",
                   onClick: () =>
-                    Share.share({
-                      url: `https://blorpblorp.xyz${linkCtx.root}c/${communityName}/posts/${encodeURIComponent(postApId)}/comments/${comment.id}`,
+                    shareRoute({
+                      route: `${linkCtx.root}c/${communityName}/posts/${encodeURIComponent(postApId)}/comments/${comment.id}`,
                     }),
                 } as const,
                 ...(isMyComment && !comment.deleted

--- a/src/components/posts/post.tsx
+++ b/src/components/posts/post.tsx
@@ -4,7 +4,7 @@ import { useSettingsStore } from "@/src/stores/settings";
 import { getPostEmbed } from "@/src/lib/post";
 import { createSlug, encodeApId, FlattenedPost } from "@/src/lib/lemmy/utils";
 
-import { Link } from "react-router-dom";
+import { Link } from "@/src/components/nav/index";
 import { PostArticleEmbed } from "./post-article-embed";
 import { PostByline } from "./post-byline";
 import { PostCommentsButton, Voting } from "./post-buttons";

--- a/src/components/universal-links.tsx
+++ b/src/components/universal-links.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from "react";
-import { useHistory } from "react-router-dom";
+import { useHistory } from "@/src/components/nav/index";
 import { App, URLOpenListenerEvent } from "@capacitor/app";
 
 export const AppUrlListener: React.FC<any> = () => {
@@ -8,7 +8,7 @@ export const AppUrlListener: React.FC<any> = () => {
     App.addListener("appUrlOpen", (event: URLOpenListenerEvent) => {
       try {
         const url = new URL(event.url);
-        history.push(url.pathname);
+        history.push(url.pathname as never);
       } catch {}
     });
   }, []);

--- a/src/features/communities-feed.tsx
+++ b/src/features/communities-feed.tsx
@@ -22,7 +22,7 @@ import {
 import { MenuButton, UserDropdown } from "../components/nav";
 import { CommunityFilter, CommunitySortSelect } from "../components/lemmy-sort";
 import { Title } from "../components/title";
-import { Link } from "react-router-dom";
+import { Link } from "@/src/components/nav/index";
 import { searchOutline } from "ionicons/icons";
 import { useAuth } from "../stores/auth";
 

--- a/src/features/community-feed.tsx
+++ b/src/features/community-feed.tsx
@@ -27,7 +27,8 @@ import {
   IonToolbar,
   useIonRouter,
 } from "@ionic/react";
-import { useParams } from "react-router";
+import { useParams } from "@/src/components/nav/index";
+import z from "zod";
 import { CommunityBanner } from "../components/communities/community-banner";
 import { useRecentCommunitiesStore } from "../stores/recent-communities";
 
@@ -35,7 +36,7 @@ import { UserDropdown } from "../components/nav";
 import { PostSortBar } from "../components/lemmy-sort";
 import { Title } from "../components/title";
 import { useLinkContext } from "../components/nav/link-context";
-import { Link } from "react-router-dom";
+import { Link } from "@/src/components/nav/index";
 import { searchOutline } from "ionicons/icons";
 import { useFiltersStore } from "../stores/filters";
 import { Button } from "../components/ui/button";
@@ -65,7 +66,7 @@ export default function CommunityFeed() {
   const router = useIonRouter();
   const [search, setSearch] = useState("");
 
-  const { communityName } = useParams<{ communityName: string }>();
+  const { communityName } = useParams(z.object({ communityName: z.string() }));
 
   const postSort = useFiltersStore((s) => s.postSort);
   const posts = usePosts({

--- a/src/features/community-sidebar.tsx
+++ b/src/features/community-sidebar.tsx
@@ -11,13 +11,14 @@ import {
   IonTitle,
   IonToolbar,
 } from "@ionic/react";
-import { useParams } from "react-router";
+import { useParams } from "@/src/components/nav/index";
+import z from "zod";
 import { useRecentCommunitiesStore } from "../stores/recent-communities";
 
 import { UserDropdown } from "../components/nav";
 import { Title } from "../components/title";
 export default function CommunityFeed() {
-  const { communityName } = useParams<{ communityName: string }>();
+  const { communityName } = useParams(z.object({ communityName: z.string() }));
 
   const community = useCommunity({
     name: communityName,

--- a/src/features/create-post.tsx
+++ b/src/features/create-post.tsx
@@ -41,7 +41,7 @@ import { Label } from "@/src/components/ui/label";
 import { cn } from "../lib/utils";
 import dayjs from "dayjs";
 import localizedFormat from "dayjs/plugin/localizedFormat";
-import { Link } from "react-router-dom";
+import { Link } from "@/src/components/nav/index";
 import { v4 as uuid } from "uuid";
 import { MdDelete } from "react-icons/md";
 import { useMedia, useUrlSearchState } from "../lib/hooks";
@@ -71,7 +71,11 @@ function DraftsSidebar({
       <div className="flex flex-row justify-between items-center">
         <h2 className="font-bold">Drafts</h2>
         <Button size="sm" variant="ghost" asChild>
-          <Link to={`/create?id=${uuid()}`} onClick={onClickDraft}>
+          <Link
+            to="/create"
+            searchParams={`?id=${uuid()}`}
+            onClick={onClickDraft}
+          >
             New
           </Link>
         </Button>
@@ -85,7 +89,8 @@ function DraftsSidebar({
           return (
             <div key={key} className="relative">
               <Link
-                to={`/create?id=${key}`}
+                to="/create"
+                searchParams={`?id=${key}`}
                 className={cn(
                   "bg-muted border px-3 py-2 gap-1 rounded-lg flex flex-col",
                   createPostId === key &&

--- a/src/features/download.tsx
+++ b/src/features/download.tsx
@@ -21,7 +21,7 @@ import Bowser from "bowser";
 import { Fragment, ReactNode, useId, useRef } from "react";
 import { cn } from "../lib/utils";
 import { Title } from "../components/title";
-import { Link } from "react-router-dom";
+import { Link } from "@/src/components/nav/index";
 import { isTauri } from "../lib/tauri";
 import { Capacitor } from "@capacitor/core";
 

--- a/src/features/home-feed.tsx
+++ b/src/features/home-feed.tsx
@@ -27,7 +27,7 @@ import { FlashList } from "../components/flashlist";
 import { MenuButton, UserDropdown } from "../components/nav";
 import { HomeFilter, PostSortBar } from "../components/lemmy-sort";
 import { useMedia } from "../lib/hooks";
-import { Link } from "react-router-dom";
+import { Link } from "@/src/components/nav/index";
 import { searchOutline } from "ionicons/icons";
 import { Button } from "../components/ui/button";
 import { FaArrowUp } from "react-icons/fa6";

--- a/src/features/inbox.tsx
+++ b/src/features/inbox.tsx
@@ -1,5 +1,5 @@
 import { CommentReplyView, PersonMentionView } from "lemmy-js-client";
-import { Link } from "react-router-dom";
+import { Link } from "@/src/components/nav/index";
 import { FlashList } from "@/src/components/flashlist";
 import { ContentGutters } from "@/src/components/gutters";
 import { MarkdownRenderer } from "../components/markdown/renderer";

--- a/src/features/post.tsx
+++ b/src/features/post.tsx
@@ -31,7 +31,8 @@ import {
   IonPage,
   IonToolbar,
 } from "@ionic/react";
-import { useParams } from "react-router";
+import { useParams } from "@/src/components/nav/index";
+import z from "zod";
 import { UserDropdown } from "../components/nav";
 import { Title } from "../components/title";
 import { useMedia, useTheme } from "../lib/hooks";
@@ -61,12 +62,17 @@ const MemoedPostCard = memo((props: PostProps) => (
 export default function Post() {
   const theme = useTheme();
   const media = useMedia();
-  const { communityName } = useParams<{ communityName: string }>();
-
-  const { post: apId, comment: commentPath } = useParams<{
-    post: string;
-    comment?: string;
-  }>();
+  const {
+    communityName,
+    post: apId,
+    comment: commentPath,
+  } = useParams(
+    z.object({
+      communityName: z.string(),
+      post: z.string(),
+      comment: z.string().optional(),
+    }),
+  );
 
   const decodedApId = apId ? decodeURIComponent(apId) : undefined;
 

--- a/src/features/saved-feed.tsx
+++ b/src/features/saved-feed.tsx
@@ -17,7 +17,7 @@ import { useLinkContext } from "../components/nav/link-context";
 import { encodeApId } from "../lib/lemmy/utils";
 import { usePostsStore } from "../stores/posts";
 import { isNotNull } from "../lib/utils";
-import { Link } from "react-router-dom";
+import { Link } from "@/src/components/nav/index";
 import {
   IonBackButton,
   IonButtons,

--- a/src/features/search.tsx
+++ b/src/features/search.tsx
@@ -20,7 +20,7 @@ import { ToggleGroup, ToggleGroupItem } from "../components/ui/toggle-group";
 import { usePostsStore } from "../stores/posts";
 import { isNotNull } from "../lib/utils";
 import { CommunityView } from "lemmy-js-client";
-import { useParams } from "react-router";
+import { useParams } from "@/src/components/nav/index";
 import {
   IonBackButton,
   IonButtons,
@@ -61,9 +61,11 @@ export function SearchFeed({
 }) {
   const media = useMedia();
 
-  const { communityName } = useParams<{
-    communityName?: string;
-  }>();
+  const { communityName } = useParams(
+    z.object({
+      communityName: z.string().optional(),
+    }),
+  );
 
   const [searchInput, setSearchInput] = useUrlSearchState("q", "", z.string());
   const [search, setSearch] = useState(searchInput);

--- a/src/features/user.tsx
+++ b/src/features/user.tsx
@@ -19,7 +19,7 @@ import { useProfilesStore } from "../stores/profiles";
 import { usePostsStore } from "../stores/posts";
 import { isNotNull } from "../lib/utils";
 import { CommentView } from "lemmy-js-client";
-import { Link, useParams } from "react-router-dom";
+import { Link, useParams } from "@/src/components/nav/index";
 import {
   IonBackButton,
   IonButtons,
@@ -91,7 +91,11 @@ const EMPTY_ARR: never[] = [];
 
 export default function User() {
   const media = useMedia();
-  const { userId } = useParams<{ userId: string }>();
+  const { userId } = useParams(
+    z.object({
+      userId: z.string(),
+    }),
+  );
 
   const actorId = userId ? decodeApId(userId) : undefined;
 

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -4,6 +4,7 @@
 import { Capacitor } from "@capacitor/core";
 import { Filesystem, Directory } from "@capacitor/filesystem";
 import { Share } from "@capacitor/share";
+import type { Route } from "../components/nav/routes.d";
 
 function blobToString(blob: Blob): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -60,4 +61,10 @@ export async function shareImage(name: string, imageUrl: string) {
     link.click();
     URL.revokeObjectURL(link.href);
   }
+}
+
+export function shareRoute({ route }: { route: Route }) {
+  return Share.share({
+    url: `https://blorpblorp.xyz${route}`,
+  });
 }


### PR DESCRIPTION
This is a good start, but it misses a bunch of things since `/c/${string}` will also match `${c}/${string}/posts/${string}`. We will likely need to do `/c/:communityName/posts/${apId}` combined with `params = {{ communityName: "", apId: "" }}` to get true type safety.

There's also the opportunity to restrict what value can be passes to `communityName` via zod. For example, `z.string().regex(/[a-z0-9]@[a-z0-9]/i)` but I would have to be 100% sure of all valid possibilities to do that.

That being said, this is already a big improvement.