### PR TITLE
fix: capitalization of 'comments' in saved feed filters

### DIFF
--- a/src/features/saved-feed.tsx
+++ b/src/features/saved-feed.tsx
@@ -128,7 +128,7 @@ export default function SavedFeed() {
                 }
               >
                 <ToggleGroupItem value="posts">Posts</ToggleGroupItem>
-                <ToggleGroupItem value="comments">comments</ToggleGroupItem>
+                <ToggleGroupItem value="comments">Comments</ToggleGroupItem>
               </ToggleGroup>
             </ToolbarButtons>
           </IonToolbar>
@@ -161,7 +161,7 @@ export default function SavedFeed() {
                     }
                   >
                     <ToggleGroupItem value="posts">Posts</ToggleGroupItem>
-                    <ToggleGroupItem value="comments">comments</ToggleGroupItem>
+                    <ToggleGroupItem value="comments">Comments</ToggleGroupItem>
                   </ToggleGroup>
                 </div>
                 <></>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/cb25ac0b-e496-4b3a-836b-4700147e9cfd)
