### PR TITLE
Login and signup flow improvements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,3 +24,4 @@ pnpm lint
 ## TypeScript
 
 - Prefer satisfies over as when writing TypeScript
+- Do not silently change `||` to `??` when fixing type errors — they are not the same. If you are certain it should be ?? you can ask the developer to confirm.

--- a/e2e/inbox.lemmy.spec.ts
+++ b/e2e/inbox.lemmy.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect, type Page } from "@playwright/test";
 import { seedAuth, jsonRoute, mockNodeinfo } from "./test-utils";
+import { normalizeInstance } from "../src/normalize-instance";
 import { SITE_WITH_USER } from "../test-utils/lemmy-api-fixtures";
 
 const TEST_JWT = "test-inbox-jwt";
@@ -29,7 +30,7 @@ async function mockInboxApis(page: Page) {
 
 test("inbox loads when logged in", async ({ page }) => {
   await seedAuth(page, {
-    instance: "lemmy.world",
+    instance: normalizeInstance("lemmy.world"),
     jwt: TEST_JWT,
     uuid: TEST_UUID,
   });

--- a/e2e/inbox.piefed.spec.ts
+++ b/e2e/inbox.piefed.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect, type Page } from "@playwright/test";
 import { seedAuth, mockNodeinfo, jsonRoute } from "./test-utils";
+import { normalizeInstance } from "../src/normalize-instance";
 
 const TEST_JWT = "test-piefed-inbox-jwt";
 const TEST_UUID = "test-piefed-inbox-uuid";
@@ -17,7 +18,7 @@ async function mockInboxApis(page: Page) {
 
 test("inbox loads when logged in", async ({ page }) => {
   await seedAuth(page, {
-    instance: "piefed.social",
+    instance: normalizeInstance("piefed.social"),
     jwt: TEST_JWT,
     uuid: TEST_UUID,
   });

--- a/e2e/login.lemmy.spec.ts
+++ b/e2e/login.lemmy.spec.ts
@@ -103,4 +103,21 @@ test.describe("login", () => {
     await openAuthModal(page, isMobile);
     await completeLogin(page, isMobile);
   });
+
+  test("hides back button when locked to default instance", async ({
+    page,
+  }, testInfo) => {
+    await page.addInitScript(() => {
+      (window as any).REACT_APP_LOCK_TO_DEFAULT_INSTANCE = "1";
+    });
+
+    const isMobile = testInfo.project.name.includes("Mobile");
+    await openAuthModal(page, isMobile);
+
+    const authModal = page.getByTestId("auth-modal");
+    await expect(
+      authModal.getByTestId("auth-change-instance"),
+    ).not.toBeVisible();
+    await expect(authModal.getByTestId("auth-close")).toBeVisible();
+  });
 });

--- a/e2e/login.lemmy.spec.ts
+++ b/e2e/login.lemmy.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 import z from "zod";
 import { SITE_WITH_USER } from "../test-utils/lemmy-api-fixtures";
 import { jsonRoute, mockNodeinfo } from "./test-utils";
@@ -6,95 +6,101 @@ import { jsonRoute, mockNodeinfo } from "./test-utils";
 const USERNAME = SITE_WITH_USER.my_user.local_user_view.person.name;
 const JWT = "sdfkhsdkfjhsdfkjshdfksjdhfskjdhfskjhsfsdfsdkjfhs";
 
-test("login", async ({ page }, testInfo) => {
-  await page.route("**/v1/instances.json", (route) => {
-    const mockPayload = [
-      {
-        url: "https://lemmy.world",
-        host: "lemmy.world",
-        description: "A generic Lemmy server for everyone to use.",
-        icon: "https://lemmy.world/pictrs/image/0fd47927-ca3a-4d2c-b2e4-a25353786671.png",
-        software: "lemmy",
-        registrationMode: "RequireApplication",
-      },
-    ];
-    return jsonRoute(route, mockPayload);
-  });
-
-  await mockNodeinfo(page, "lemmy");
-
-  await page.route("**/api/**/user/login", async (route, request) => {
-    const body = request.postDataJSON();
-    const { totp_2fa_token } = z
-      .object({
-        totp_2fa_token: z.string().optional(),
-      })
-      .parse(body);
-
-    if (!totp_2fa_token) {
-      return jsonRoute(route, { error: "missing_totp_token" }, 400);
-    }
-
-    const mockPayload = {
-      jwt: JWT,
-      registration_created: false,
-      verify_email_sent: false,
-    };
-    return jsonRoute(route, mockPayload);
-  });
-
-  await page.route("**/api/**/site?", async (route, request) => {
-    const loggedIn = request.headers()["authorization"]?.includes(JWT);
-    const payload = loggedIn
-      ? SITE_WITH_USER
-      : { ...SITE_WITH_USER, my_user: undefined };
-    return jsonRoute(route, payload);
-  });
-
-  const isMobile = testInfo.project.name.includes("Mobile");
-
+async function openAuthModal(page: Page, isMobile: boolean) {
   await page.goto("/home");
-
   await expect(page.getByText(USERNAME)).not.toBeVisible();
 
   if (isMobile) {
-    await expect(page.getByTestId("user-sidebar-trigger")).toBeVisible();
     await page.getByTestId("user-sidebar-trigger").click();
-  } else {
-    await expect(page.getByTestId("user-dropdown-trigger")).toBeVisible();
-    await page.getByTestId("user-dropdown-trigger").click();
-  }
-
-  await expect(page.getByText("Logout")).not.toBeVisible();
-
-  if (isMobile) {
     await page.getByTestId("user-sidebar-login").click();
   } else {
+    await page.getByTestId("user-dropdown-trigger").click();
+    await expect(page.getByText("Logout")).not.toBeVisible();
     await page.getByTestId("user-dropdown-login").click();
   }
+}
 
+async function completeLogin(page: Page, isMobile: boolean) {
   const authModal = page.getByTestId("auth-modal");
-  await authModal.getByTestId("auth-change-instance").click();
-  await page.getByTestId("auth-filter-lemmy").click();
-  await authModal.getByText("lemmy.world").click();
   await authModal.getByPlaceholder("Username").fill("jondoe");
   await authModal.getByPlaceholder("Password").fill("password");
-
   await page.getByText("Sign In").click();
 
   await expect(page.getByText(USERNAME).first()).not.toBeAttached();
-
   await authModal.getByTestId("otp-input").fill("123456");
-
   await expect(page.getByText(USERNAME).first()).toBeAttached();
 
   if (isMobile) {
     await page.getByTestId("user-sidebar-trigger").click();
-    const dropdown = page.getByTestId("user-sidebar-content");
-    await expect(dropdown.getByText("Logout")).toBeVisible();
+    await expect(
+      page.getByTestId("user-sidebar-content").getByText("Logout"),
+    ).toBeVisible();
   } else {
     await page.getByTestId("user-dropdown-trigger").click();
-    const dropdown = page.getByTestId("user-dropdown-content");
-    await expect(dropdown.getByText("Logout")).toBeVisible();
+    await expect(
+      page.getByTestId("user-dropdown-content").getByText("Logout"),
+    ).toBeVisible();
   }
+}
+
+test.describe("login", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route("**/v1/instances.json", (route) =>
+      jsonRoute(route, [
+        {
+          url: "https://lemmy.world",
+          host: "lemmy.world",
+          description: "A generic Lemmy server for everyone to use.",
+          icon: "https://lemmy.world/pictrs/image/0fd47927-ca3a-4d2c-b2e4-a25353786671.png",
+          software: "lemmy",
+          registrationMode: "RequireApplication",
+        },
+      ]),
+    );
+
+    await mockNodeinfo(page, "lemmy");
+
+    await page.route("**/api/**/user/login", async (route, request) => {
+      const body = request.postDataJSON();
+      const { totp_2fa_token } = z
+        .object({ totp_2fa_token: z.string().optional() })
+        .parse(body);
+
+      if (!totp_2fa_token) {
+        return jsonRoute(route, { error: "missing_totp_token" }, 400);
+      }
+
+      return jsonRoute(route, {
+        jwt: JWT,
+        registration_created: false,
+        verify_email_sent: false,
+      });
+    });
+
+    await page.route("**/api/**/site?", async (route, request) => {
+      const loggedIn = request.headers()["authorization"]?.includes(JWT);
+      const payload = loggedIn
+        ? SITE_WITH_USER
+        : { ...SITE_WITH_USER, my_user: undefined };
+      return jsonRoute(route, payload);
+    });
+  });
+
+  test("via instance selection", async ({ page }, testInfo) => {
+    const isMobile = testInfo.project.name.includes("Mobile");
+    await openAuthModal(page, isMobile);
+
+    const authModal = page.getByTestId("auth-modal");
+    await authModal.getByTestId("auth-change-instance").click();
+    await page.getByTestId("auth-filter-lemmy").click();
+    await authModal.getByText("lemmy.world").click();
+
+    await completeLogin(page, isMobile);
+  });
+
+  test("with default instance", async ({ page }, testInfo) => {
+    const isMobile = testInfo.project.name.includes("Mobile");
+    await openAuthModal(page, isMobile);
+    await completeLogin(page, isMobile);
+  });
 });

--- a/e2e/login.lemmy.spec.ts
+++ b/e2e/login.lemmy.spec.ts
@@ -74,6 +74,7 @@ test("login", async ({ page }, testInfo) => {
   }
 
   const authModal = page.getByTestId("auth-modal");
+  await authModal.getByTestId("auth-change-instance").click();
   await page.getByTestId("auth-filter-lemmy").click();
   await authModal.getByText("lemmy.world").click();
   await authModal.getByPlaceholder("Username").fill("jondoe");

--- a/e2e/login.piefed.spec.ts
+++ b/e2e/login.piefed.spec.ts
@@ -48,6 +48,7 @@ test("login", async ({ page }, testInfo) => {
   }
 
   const authModal = page.getByTestId("auth-modal");
+  await authModal.getByTestId("auth-change-instance").click();
   await page.getByTestId("auth-filter-piefed").click();
   await authModal.getByText("piefed.social").click();
   await authModal.getByPlaceholder("Username").fill(USERNAME);

--- a/e2e/post.lemmy.spec.ts
+++ b/e2e/post.lemmy.spec.ts
@@ -6,6 +6,7 @@ import {
   SITE_WITH_USER,
 } from "../test-utils/lemmy-api-fixtures";
 import { seedAuth, jsonRoute, mockNodeinfo } from "./test-utils";
+import { normalizeInstance } from "../src/normalize-instance";
 
 const tabs = [
   { name: "home", base: "/home/" },
@@ -62,7 +63,7 @@ for (const { name, base } of tabs) {
 
 test("upvoting a post hits the vote endpoint", async ({ page }) => {
   await seedAuth(page, {
-    instance: "lemmy.world",
+    instance: normalizeInstance("lemmy.world"),
     jwt: "test-post-jwt",
     uuid: "test-post-uuid",
   });

--- a/e2e/post.piefed.spec.ts
+++ b/e2e/post.piefed.spec.ts
@@ -6,6 +6,7 @@ import {
   RESOLVE_POST_RES,
 } from "../test-utils/piefed-api-fixtures";
 import { seedAuth, mockNodeinfo, jsonRoute } from "./test-utils";
+import { normalizeInstance } from "../src/normalize-instance";
 
 const tabs = [
   { name: "home", base: "/home/" },
@@ -72,7 +73,7 @@ for (const { name, base } of tabs) {
 
 test("upvoting a post hits the vote endpoint", async ({ page }) => {
   await seedAuth(page, {
-    instance: "piefed.social",
+    instance: normalizeInstance("piefed.social"),
     jwt: "test-piefed-post-jwt",
     uuid: "test-piefed-post-uuid",
   });

--- a/e2e/signup.lemmy.spec.ts
+++ b/e2e/signup.lemmy.spec.ts
@@ -1,0 +1,156 @@
+import { test, expect, type Page } from "@playwright/test";
+import { SITE_WITH_USER } from "../test-utils/lemmy-api-fixtures";
+import { jsonRoute, mockNodeinfo } from "./test-utils";
+
+const USERNAME = SITE_WITH_USER.my_user.local_user_view.person.name;
+const JWT = "signup-test-jwt";
+
+const CAPTCHA_UUID = "test-captcha-uuid";
+const CAPTCHA_IMG = "aGVsbG8=";
+const CAPTCHA_WAV = "d29ybGQ=";
+
+async function openSignupForm(page: Page, isMobile: boolean) {
+  await page.goto("/home");
+
+  if (isMobile) {
+    await page.getByTestId("user-sidebar-trigger").click();
+    await page.getByTestId("user-sidebar-login").click();
+  } else {
+    await page.getByTestId("user-dropdown-trigger").click();
+    await page.getByTestId("user-dropdown-login").click();
+  }
+
+  await page.getByRole("button", { name: "Need an account?" }).click();
+}
+
+test.describe("signup", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockNodeinfo(page, "lemmy");
+
+    await page.route("**/api/**/user/get_captcha*", (route) =>
+      jsonRoute(route, {
+        ok: {
+          uuid: CAPTCHA_UUID,
+          png: CAPTCHA_IMG,
+          wav: CAPTCHA_WAV,
+        },
+      }),
+    );
+  });
+
+  test("submits correct payload and logs in on success", async ({
+    page,
+  }, testInfo) => {
+    const isMobile = testInfo.project.name.includes("Mobile");
+
+    await page.route("**/api/**/site?*", async (route, request) => {
+      const loggedIn = request.headers()["authorization"]?.includes(JWT);
+      return jsonRoute(
+        route,
+        loggedIn ? SITE_WITH_USER : { ...SITE_WITH_USER, my_user: undefined },
+      );
+    });
+
+    await page.route("**/api/**/user/register", (route) =>
+      jsonRoute(route, {
+        jwt: JWT,
+        registration_created: false,
+        verify_email_sent: false,
+      }),
+    );
+
+    await openSignupForm(page, isMobile);
+
+    const signupForm = page.getByTestId("signup-form");
+    await signupForm.getByPlaceholder("Email").fill("newuser@example.com");
+    await signupForm.getByPlaceholder("Username").fill("newuser");
+    await signupForm.getByPlaceholder("Enter password").fill("hunter2");
+    await signupForm.getByPlaceholder("Confirm password").fill("hunter2");
+    await signupForm.getByPlaceholder("Captcha answer").fill("correct-answer");
+    await signupForm.getByPlaceholder("Application answer").fill("test answer");
+
+    const registerRequest = page.waitForRequest("**/api/**/user/register");
+    await signupForm.getByRole("button", { name: "Sign up" }).click();
+    const req = await registerRequest;
+
+    expect(req.postDataJSON()).toMatchObject({
+      username: "newuser",
+      password: "hunter2",
+      password_verify: "hunter2",
+      email: "newuser@example.com",
+      captcha_uuid: CAPTCHA_UUID,
+      captcha_answer: "correct-answer",
+      answer: "test answer",
+    });
+
+    await expect(page.getByText(USERNAME).first()).toBeAttached();
+
+    if (isMobile) {
+      await page.getByTestId("user-sidebar-trigger").click();
+      await expect(
+        page.getByTestId("user-sidebar-content").getByText("Logout"),
+      ).toBeVisible();
+    } else {
+      await page.getByTestId("user-dropdown-trigger").click();
+      await expect(
+        page.getByTestId("user-dropdown-content").getByText("Logout"),
+      ).toBeVisible();
+    }
+  });
+
+  test("shows closed registration banner", async ({ page }, testInfo) => {
+    const isMobile = testInfo.project.name.includes("Mobile");
+
+    await page.route("**/api/**/site?*", (route) =>
+      jsonRoute(route, {
+        ...SITE_WITH_USER,
+        my_user: undefined,
+        site_view: {
+          ...SITE_WITH_USER.site_view,
+          local_site: {
+            ...SITE_WITH_USER.site_view.local_site,
+            registration_mode: "Closed",
+          },
+        },
+      }),
+    );
+
+    await openSignupForm(page, isMobile);
+
+    await expect(
+      page.getByText("This instance is not currently accepting registrations"),
+    ).toBeVisible();
+  });
+
+  test("shows application question when registration requires application", async ({
+    page,
+  }, testInfo) => {
+    const isMobile = testInfo.project.name.includes("Mobile");
+    const applicationQuestion =
+      "Why do you want to join? Please describe yourself.";
+
+    await page.route("**/api/**/site?*", (route) =>
+      jsonRoute(route, {
+        ...SITE_WITH_USER,
+        my_user: undefined,
+        site_view: {
+          ...SITE_WITH_USER.site_view,
+          local_site: {
+            ...SITE_WITH_USER.site_view.local_site,
+            registration_mode: "RequireApplication",
+            application_question: applicationQuestion,
+          },
+        },
+      }),
+    );
+
+    await openSignupForm(page, isMobile);
+
+    await expect(
+      page.getByText(
+        "To join this server, you need to fill out the application below",
+      ),
+    ).toBeVisible();
+    await expect(page.getByText(applicationQuestion)).toBeVisible();
+  });
+});

--- a/e2e/test-utils.ts
+++ b/e2e/test-utils.ts
@@ -1,5 +1,5 @@
 import type { Page, Route } from "@playwright/test";
-import type { AuthStoreData } from "@/src/stores/auth";
+import type { Account, AuthStoreData } from "@/src/stores/auth";
 import { DB_NAME, DB_VERSION, TABLE_NAME } from "@/src/lib/db-constants";
 
 // The zustand persist middleware stores keys as `${rowName}_${persistName}`.
@@ -34,10 +34,7 @@ export async function mockNodeinfo(page: Page, software: "lemmy" | "piefed") {
   );
 }
 
-export async function seedAuth(
-  page: Page,
-  account: AuthStoreData["accounts"][number],
-) {
+export async function seedAuth(page: Page, account: Account) {
   const authState = {
     state: {
       accounts: [account],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -218,4 +218,13 @@ export default tseslint.config(
       ],
     },
   },
+  {
+    files: ["**/*.test.ts", "**/*.test.tsx"],
+    plugins: { local },
+    rules: {
+      "local/query-hook-naming": "off",
+      "local/mutation-hook-naming": "off",
+      "import-x/first": "off",
+    },
+  },
 );

--- a/package.json
+++ b/package.json
@@ -48,6 +48,8 @@
     "@panzoom/panzoom": "4.6.1",
     "@radix-ui/react-collapsible": "1.1.12",
     "@radix-ui/react-hover-card": "1.1.15",
+    "@radix-ui/react-label": "2.1.8",
+    "@radix-ui/react-separator": "1.1.8",
     "@radix-ui/react-slot": "1.2.4",
     "@tailwindcss/vite": "4.2.1",
     "@tanstack/pacer": "0.14.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,12 @@ importers:
       "@radix-ui/react-hover-card":
         specifier: 1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      "@radix-ui/react-label":
+        specifier: 2.1.8
+        version: 2.1.8(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      "@radix-ui/react-separator":
+        specifier: 1.1.8
+        version: 1.1.8(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       "@radix-ui/react-slot":
         specifier: 1.2.4
         version: 1.2.4(@types/react@19.2.7)(react@19.2.0)
@@ -3218,6 +3224,22 @@ packages:
       "@types/react-dom":
         optional: true
 
+  "@radix-ui/react-label@2.1.8":
+    resolution:
+      {
+        integrity: sha512-FmXs37I6hSBVDlO4y764TNz1rLgKwjJMQ0EGte6F3Cb3f4bIuHB/iLa/8I9VKkmOy+gNHq8rql3j686ACVV21A==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      "@types/react-dom": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+      "@types/react-dom":
+        optional: true
+
   "@radix-ui/react-menu@2.1.16":
     resolution:
       {
@@ -3478,6 +3500,22 @@ packages:
     resolution:
       {
         integrity: sha512-0HEb8R9E8A+jZjvmFCy/J4xhbXy3TV+9XSnGJ3KvTtjlIUy/YQ/p6UYZvi7YbeoeXdyU9+Y3scizK6hkY37baA==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      "@types/react-dom": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+      "@types/react-dom":
+        optional: true
+
+  "@radix-ui/react-separator@1.1.8":
+    resolution:
+      {
+        integrity: sha512-sDvqVY4itsKwwSMEe0jtKgfTh+72Sy3gPmQpjqcQneqQ4PFmr/1I0YA+2/puilhggCe2gJcx5EBAYFkWkdpa5g==,
       }
     peerDependencies:
       "@types/react": "*"
@@ -15084,6 +15122,15 @@ snapshots:
       "@types/react": 19.2.7
       "@types/react-dom": 19.2.3(@types/react@19.2.7)
 
+  "@radix-ui/react-label@2.1.8(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)":
+    dependencies:
+      "@radix-ui/react-primitive": 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      "@types/react": 19.2.7
+      "@types/react-dom": 19.2.3(@types/react@19.2.7)
+
   "@radix-ui/react-menu@2.1.16(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)":
     dependencies:
       "@radix-ui/primitive": 1.1.3
@@ -15359,6 +15406,15 @@ snapshots:
   "@radix-ui/react-separator@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)":
     dependencies:
       "@radix-ui/react-primitive": 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      "@types/react": 19.2.7
+      "@types/react-dom": 19.2.3(@types/react@19.2.7)
+
+  "@radix-ui/react-separator@1.1.8(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)":
+    dependencies:
+      "@radix-ui/react-primitive": 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
     optionalDependencies:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,7 +16,7 @@ import { updateTauri } from "./lib/tauri";
 import { ReactQueryDevtoolsPanel } from "@tanstack/react-query-devtools";
 import { TanstackDevtools } from "@tanstack/react-devtools";
 import { TanstackQueryProvider } from "./tanstack-query/index";
-import { AuthProvider } from "./components/auth-context";
+import { AuthProvider } from "./features/auth";
 import { PostRemoveProvider } from "./components/posts/post-remove";
 import { Toaster } from "./components/ui/sonner";
 

--- a/src/apis/client.ts
+++ b/src/apis/client.ts
@@ -7,7 +7,14 @@ import { PieFedApi } from "./piefed";
 
 const nodeInfoSchema = z.object({
   software: z.object({
-    name: z.enum(["lemmy", "piefed"], { message: "Unsupported software" }),
+    name: z.enum(["lemmy", "piefed"], {
+      errorMap: (issue) => ({
+        message:
+          issue.code === z.ZodIssueCode.invalid_enum_value
+            ? `Unsupported software: "${issue.received}"`
+            : "Unsupported software",
+      }),
+    }),
     version: z.string(),
   }),
 });

--- a/src/apis/client.ts
+++ b/src/apis/client.ts
@@ -7,7 +7,7 @@ import { PieFedApi } from "./piefed";
 
 const nodeInfoSchema = z.object({
   software: z.object({
-    name: z.enum(["lemmy", "piefed"]),
+    name: z.enum(["lemmy", "piefed"], { message: "Unsupported software" }),
     version: z.string(),
   }),
 });

--- a/src/apis/client.ts
+++ b/src/apis/client.ts
@@ -3,18 +3,15 @@ import { LemmyV4Api } from "./lemmy-v4";
 import { ApiBlueprint } from "./api-blueprint";
 import z from "zod";
 import _ from "lodash";
+import { zodEnumMessage } from "../lib/zod";
 import { PieFedApi } from "./piefed";
 
 const nodeInfoSchema = z.object({
   software: z.object({
-    name: z.enum(["lemmy", "piefed"], {
-      errorMap: (issue) => ({
-        message:
-          issue.code === z.ZodIssueCode.invalid_enum_value
-            ? `Unsupported software: "${issue.received}"`
-            : "Unsupported software",
-      }),
-    }),
+    name: z.enum(
+      ["lemmy", "piefed"],
+      zodEnumMessage`Unsupported software: ${(i) => i.received}`,
+    ),
     version: z.string(),
   }),
 });

--- a/src/components/comments/comment-buttons.tsx
+++ b/src/components/comments/comment-buttons.tsx
@@ -1,7 +1,6 @@
 import { useLikeCommentMutation } from "@/src/queries/index";
 import { resolveVoteCounts } from "@/src/lib/voting";
 import { useVoteHaptics } from "@/src/hooks/use-vote-haptics";
-import { useRequireAuth } from "../auth-context";
 import { ButtonHTMLAttributes, DetailedHTMLProps, useId } from "react";
 import { cn } from "@/src/lib/utils";
 import {
@@ -17,7 +16,7 @@ import { abbriviateNumber, abbriviateNumberParts } from "@/src/lib/format";
 import { Schemas } from "@/src/apis/api-blueprint";
 import { Tooltip, TooltipTrigger, TooltipContent } from "../ui/tooltip";
 import { useDoubleTap } from "use-double-tap";
-import { useMedia } from "@/src/hooks";
+import { useMedia, useRequireAuth } from "@/src/hooks";
 import { useSettingsStore } from "@/src/stores/settings";
 import { useShouldShowDownvotes, useScoreDisplay } from "@/src/stores/utils";
 import { Separator } from "../ui/separator";

--- a/src/components/comments/post-comment.tsx
+++ b/src/components/comments/post-comment.tsx
@@ -23,7 +23,6 @@ import {
 } from "@/src/queries/index";
 import { CommentTree } from "@/src/lib/comment-tree";
 import { useShowCommentReportModal } from "../posts/post-report";
-import { useRequireAuth } from "../auth-context";
 import { useLinkContext } from "@/src/hooks/navigation-hooks";
 import {
   encodeApId,
@@ -55,7 +54,7 @@ import {
 } from "../ui/collapsible";
 import { create } from "zustand";
 import { COMMENT_COLLAPSE_EVENT } from "../posts/config";
-import { useMedia, useInputAlert } from "@/src/hooks/index";
+import { useMedia, useInputAlert, useRequireAuth } from "@/src/hooks";
 import { CakeDay } from "../cake-day";
 import { useTagUserStore } from "@/src/stores/user-tags";
 import { useSettingsStore } from "@/src/stores/settings";

--- a/src/components/nav.tsx
+++ b/src/components/nav.tsx
@@ -15,7 +15,6 @@ import {
   AvatarFallback,
   AvatarImage,
 } from "@/src/components/ui/avatar";
-import { useRequireAuth } from "./auth-context";
 import { IonMenuButton, IonMenuToggle } from "@ionic/react";
 import { IoPerson, IoSettingsOutline } from "react-icons/io5";
 import {
@@ -26,7 +25,7 @@ import {
   usePrivateMessagesCountQuery,
 } from "../queries";
 import { LuMenu } from "react-icons/lu";
-import { useConfirmationAlert, useMedia } from "../hooks";
+import { useConfirmationAlert, useMedia, useRequireAuth } from "../hooks";
 import {
   IoPersonOutline,
   IoBookmarksOutline,

--- a/src/components/page/index.tsx
+++ b/src/components/page/index.tsx
@@ -6,14 +6,13 @@ import {
   IonToolbar,
   useIonRouter,
 } from "@ionic/react";
-import { useRequireAuth } from "../auth-context";
 import { ContentGutters } from "../gutters";
 import { Button } from "../ui/button";
 import { MenuButton, UserDropdown } from "../nav";
 import { ToolbarButtons } from "../toolbar/toolbar-buttons";
 import { ToolbarTitle } from "../toolbar/toolbar-title";
 import { ToolbarBackButton } from "../toolbar/toolbar-back-button";
-import { usePathname } from "@/src/hooks/use-pathname";
+import { usePathname, useRequireAuth } from "@/src/hooks";
 import { STACK_ROOT_PATHS } from "../../routing/routes";
 import { NotFoundPageContent } from "./not-found";
 import { ErrorBoundary } from "react-error-boundary";

--- a/src/components/page/not-found.tsx
+++ b/src/components/page/not-found.tsx
@@ -19,8 +19,8 @@ import { IoPerson } from "react-icons/io5";
 import { resolveRoute } from "../../routing";
 import { encodeApId, apIdFromCommunitySlug } from "../../apis/utils";
 import { Schemas } from "../../apis/api-blueprint";
-import { useRequireAuth } from "../auth-context";
 import { env } from "../../env";
+import { useRequireAuth } from "@/src/hooks";
 
 function buildRedirectUrl(data: Schemas.ResolveObject): string | undefined {
   if (data.post) {

--- a/src/components/person/person-action-menu.tsx
+++ b/src/components/person/person-action-menu.tsx
@@ -4,7 +4,6 @@ import { EllipsisActionMenu, SubAction } from "../adaptable/action-menu";
 import { encodeApId } from "@/src/apis/utils";
 import { Deferred } from "@/src/lib/deferred";
 import { useIonAlert, useIonRouter } from "@ionic/react";
-import { useRequireAuth } from "../auth-context";
 import { useBlockPersonMutation } from "@/src/queries";
 import {
   getAccountActorId,
@@ -15,7 +14,7 @@ import { useShareActions } from "@/src/components/adaptable/action-menu/hooks";
 import { resolveRoute } from "../../routing/index";
 import { Schemas } from "@/src/apis/api-blueprint";
 import { useTagUserStore } from "@/src/stores/user-tags";
-import { useTagUser } from "@/src/hooks/use-tag-user";
+import { useTagUser, useRequireAuth } from "@/src/hooks";
 import { useLinkContext } from "@/src/hooks/navigation-hooks";
 
 dayjs.extend(localizedFormat);

--- a/src/components/posts/embeds/post-poll-embed.tsx
+++ b/src/components/posts/embeds/post-poll-embed.tsx
@@ -8,11 +8,11 @@ import { Button } from "../../ui/button";
 import utc from "dayjs/plugin/utc";
 import dayjs from "dayjs";
 import { useVotePostPollMutation } from "@/src/queries/post-mutations";
-import { useRequireAuth } from "../../auth-context";
 import { getAccountSite, useAuth } from "@/src/stores/auth";
 import { ABOVE_LINK_OVERLAY } from "../config";
 import { PersonAvatar } from "../../person/person-avatar";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../../ui/tooltip";
+import { useRequireAuth } from "@/src/hooks";
 dayjs.extend(utc);
 
 function formatPercent(value: number) {

--- a/src/components/posts/post-buttons.tsx
+++ b/src/components/posts/post-buttons.tsx
@@ -1,6 +1,5 @@
 import { resolveVoteCounts } from "@/src/lib/voting";
 import { useVoteHaptics } from "@/src/hooks/use-vote-haptics";
-import { useRequireAuth } from "../auth-context";
 import { Link, resolveRoute } from "@/src/routing/index";
 import {
   PiArrowFatUpBold,
@@ -36,7 +35,7 @@ import {
 } from "../ui/hover-card";
 import { useDoubleTap } from "use-double-tap";
 import { Schemas } from "@/src/apis/api-blueprint";
-import { useMedia } from "@/src/hooks";
+import { useMedia, useRequireAuth } from "@/src/hooks";
 import {
   useAddPostReactionEmojiMutation,
   useLikePostMutation,

--- a/src/components/posts/post-byline.tsx
+++ b/src/components/posts/post-byline.tsx
@@ -1,8 +1,7 @@
 import { useLinkContext } from "@/src/hooks/navigation-hooks";
-import { useRequireAuth } from "../auth-context";
 import { useShowPostReportModal } from "./post-report";
 import { useAuth, getAccountActorId, useIsAdmin } from "@/src/stores/auth";
-import { useShouldBlurNsfw } from "@/src/hooks/nsfw";
+import { useShouldBlurNsfw, useRequireAuth } from "@/src/hooks";
 import { useNsfwRevealedPostsStore } from "@/src/stores/nsfw-revealed-posts";
 import { COMMUNITY_NSFW_ICON_BLUR_CLASS } from "@/src/components/communities/utils";
 import { Link, resolveRoute } from "@/src/routing/index";

--- a/src/components/posts/post.tsx
+++ b/src/components/posts/post.tsx
@@ -31,7 +31,7 @@ import {
   useAuth,
   useIsInstanceBlocked,
 } from "@/src/stores/auth";
-import { useShouldShowNsfw } from "@/src/hooks/nsfw";
+import { useShouldShowNsfw, useRequireAuth } from "@/src/hooks";
 import { LuRepeat2 } from "react-icons/lu";
 import { Schemas } from "@/src/apis/api-blueprint";
 import { Separator } from "../ui/separator";

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -5,14 +5,13 @@ import { useCreatePostStore } from "@/src/stores/create-post";
 import { resolveRoute } from "@/src/routing";
 import { v4 as uuid } from "uuid";
 import { useIonRouter } from "@ionic/react";
-import { usePathname } from "@/src/hooks/use-pathname";
+import { usePathname, useRequireAuth } from "@/src/hooks";
 import { Button } from "./ui/button";
 import {
   BLORP_COMMUNITY,
   buildErrorReport,
   buildIssueUrl,
 } from "@/src/lib/error-reporting";
-import { useRequireAuth } from "./auth-context";
 
 function SidebarErrorFallback({
   error,

--- a/src/components/ui/field.tsx
+++ b/src/components/ui/field.tsx
@@ -1,0 +1,246 @@
+import { useMemo } from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/src/lib/utils";
+import { Label } from "@/src/components/ui/label";
+import { Separator } from "@/src/components/ui/separator";
+
+function FieldSet({ className, ...props }: React.ComponentProps<"fieldset">) {
+  return (
+    <fieldset
+      data-slot="field-set"
+      className={cn(
+        "flex flex-col gap-6",
+        "has-[>[data-slot=checkbox-group]]:gap-3 has-[>[data-slot=radio-group]]:gap-3",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function FieldLegend({
+  className,
+  variant = "legend",
+  ...props
+}: React.ComponentProps<"legend"> & { variant?: "legend" | "label" }) {
+  return (
+    <legend
+      data-slot="field-legend"
+      data-variant={variant}
+      className={cn(
+        "mb-3 font-medium",
+        "data-[variant=legend]:text-base",
+        "data-[variant=label]:text-sm",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function FieldGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="field-group"
+      className={cn(
+        "group/field-group @container/field-group flex w-full flex-col gap-7 data-[slot=checkbox-group]:gap-3 [&>[data-slot=field-group]]:gap-4",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+const fieldVariants = cva(
+  "group/field data-[invalid=true]:text-destructive flex w-full gap-1",
+  {
+    variants: {
+      orientation: {
+        vertical: ["flex-col [&>*]:w-full [&>.sr-only]:w-auto"],
+        horizontal: [
+          "flex-row items-center",
+          "[&>[data-slot=field-label]]:flex-auto",
+          "has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px has-[>[data-slot=field-content]]:items-start",
+        ],
+        responsive: [
+          "@md/field-group:flex-row @md/field-group:items-center @md/field-group:[&>*]:w-auto flex-col [&>*]:w-full [&>.sr-only]:w-auto",
+          "@md/field-group:[&>[data-slot=field-label]]:flex-auto",
+          "@md/field-group:has-[>[data-slot=field-content]]:items-start @md/field-group:has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px",
+        ],
+      },
+    },
+    defaultVariants: {
+      orientation: "vertical",
+    },
+  },
+);
+
+function Field({
+  className,
+  orientation = "vertical",
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof fieldVariants>) {
+  return (
+    <div
+      role="group"
+      data-slot="field"
+      data-orientation={orientation}
+      className={cn(fieldVariants({ orientation }), className)}
+      {...props}
+    />
+  );
+}
+
+function FieldContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="field-content"
+      className={cn(
+        "group/field-content flex flex-1 flex-col gap-1.5 leading-snug",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function FieldLabel({
+  className,
+  required,
+  ...props
+}: React.ComponentProps<typeof Label> & { required?: boolean }) {
+  return (
+    <Label
+      data-slot="field-label"
+      className={cn(
+        "group/field-label peer/field-label flex w-fit gap-1 leading-snug group-data-[disabled=true]/field:opacity-50",
+        "has-[>[data-slot=field]]:w-full has-[>[data-slot=field]]:flex-col has-[>[data-slot=field]]:rounded-md has-[>[data-slot=field]]:border [&>[data-slot=field]]:p-4",
+        "has-data-[state=checked]:bg-primary/5 has-data-[state=checked]:border-primary dark:has-data-[state=checked]:bg-primary/10",
+        className,
+      )}
+      {...props}
+    >
+      {props.children}
+      {required && <span className="text-destructive">*</span>}
+    </Label>
+  );
+}
+
+function FieldTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="field-label"
+      className={cn(
+        "flex w-fit items-center gap-2 text-sm font-medium leading-snug group-data-[disabled=true]/field:opacity-50",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function FieldDescription({ className, ...props }: React.ComponentProps<"p">) {
+  return (
+    <p
+      data-slot="field-description"
+      className={cn(
+        "text-muted-foreground text-sm font-normal leading-normal group-has-[[data-orientation=horizontal]]/field:text-balance",
+        "nth-last-2:-mt-1 last:mt-0 [[data-variant=legend]+&]:-mt-1.5",
+        "[&>a:hover]:text-primary [&>a]:underline [&>a]:underline-offset-4",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function FieldSeparator({
+  children,
+  className,
+  ...props
+}: React.ComponentProps<"div"> & {
+  children?: React.ReactNode;
+}) {
+  return (
+    <div
+      data-slot="field-separator"
+      data-content={!!children}
+      className={cn(
+        "relative -my-2 h-5 text-sm group-data-[variant=outline]/field-group:-mb-2",
+        className,
+      )}
+      {...props}
+    >
+      <Separator className="absolute inset-0 top-1/2" />
+      {children && (
+        <span
+          className="bg-background text-muted-foreground relative mx-auto block w-fit px-2"
+          data-slot="field-separator-content"
+        >
+          {children}
+        </span>
+      )}
+    </div>
+  );
+}
+
+function FieldError({
+  className,
+  children,
+  errors,
+  ...props
+}: React.ComponentProps<"div"> & {
+  errors?: Array<{ message?: string } | undefined>;
+}) {
+  const content = useMemo(() => {
+    if (children) {
+      return children;
+    }
+
+    if (!errors) {
+      return null;
+    }
+
+    if (errors?.length === 1 && errors[0]?.message) {
+      return errors[0].message;
+    }
+
+    return (
+      <ul className="ms-4 flex list-disc flex-col gap-1">
+        {errors.map(
+          (error, index) =>
+            error?.message && <li key={index}>{error.message}</li>,
+        )}
+      </ul>
+    );
+  }, [children, errors]);
+
+  if (!content) {
+    return null;
+  }
+
+  return (
+    <div
+      role="alert"
+      data-slot="field-error"
+      className={cn("text-destructive text-sm font-normal", className)}
+      {...props}
+    >
+      {content}
+    </div>
+  );
+}
+
+export {
+  Field,
+  FieldLabel,
+  FieldDescription,
+  FieldError,
+  FieldGroup,
+  FieldLegend,
+  FieldSeparator,
+  FieldSet,
+  FieldContent,
+  FieldTitle,
+};

--- a/src/components/use-report-error.ts
+++ b/src/components/use-report-error.ts
@@ -1,6 +1,5 @@
 import { useIonRouter } from "@ionic/react";
 import { useCreatePostStore } from "@/src/stores/create-post";
-import { useRequireAuth } from "@/src/components/auth-context";
 import { parseAccountInfo, useAuth } from "@/src/stores/auth";
 import { resolveRoute } from "@/src/routing/index";
 import { v4 as uuid } from "uuid";
@@ -9,6 +8,7 @@ import {
   buildErrorReport,
   buildIssueUrl,
 } from "@/src/lib/error-reporting";
+import { useRequireAuth } from "../hooks";
 
 export function useReportError({
   contextFields,

--- a/src/env.ts
+++ b/src/env.ts
@@ -151,7 +151,8 @@ export const defaultInstances = (() => {
   }
 })();
 
-const defaultInstance = defaultInstances[0] || FALLBACK_INSTANCE;
+const defaultInstance =
+  defaultInstances[0] || normalizeInstance(FALLBACK_INSTANCE);
 
 export const env = {
   ...config,

--- a/src/features/auth.tsx
+++ b/src/features/auth.tsx
@@ -322,7 +322,7 @@ function InstanceSelectionPage({
           value={software ?? "all"}
           onValueChange={(val) => val && setSoftware(val as Software)}
         >
-          <ToggleGroupItem value="all" data-testid="auth-filter-lemmy">
+          <ToggleGroupItem value="all" data-testid="auth-filter-all">
             All ({counts.all})
           </ToggleGroupItem>
           <ToggleGroupItem value="lemmy" data-testid="auth-filter-lemmy">
@@ -825,6 +825,11 @@ function AuthModal({
           <ToolbarButtons side="left">
             <IonButton
               className="size-5"
+              data-testid={
+                step !== "instance-selection"
+                  ? "auth-change-instance"
+                  : "auth-close"
+              }
               onClick={() => {
                 if (
                   step !== "instance-selection" &&

--- a/src/features/auth.tsx
+++ b/src/features/auth.tsx
@@ -578,7 +578,7 @@ function SignupForm({
   const applicationQuestion = site.data?.site.applicationQuestion;
 
   return (
-    <div className="p-4 overflow-y-auto ion-content-scroll-host h-full">
+    <div className="p-6 overflow-y-auto ion-content-scroll-host h-full">
       {site.data?.site.software === "piefed" && (
         <div className="bg-destructive text-background p-1 rounded-md text-center mb-4 sticky top-0">
           PieFed doesn't yet support registrations through 3rd party clients
@@ -594,11 +594,22 @@ function SignupForm({
 
       <form
         onSubmit={submitLogin}
-        className="gap-4 flex flex-col"
+        className="gap-5 flex flex-col"
         data-testid="signup-form"
       >
-        <div className="flex flex-col gap-1">
-          <label className="text-muted-foreground text-sm">Email</label>
+        <span className="text-2xl font-bold">
+          Let's get you set up on {instance.baseurl}.
+        </span>
+
+        <p>
+          With an account on this server, you'll be able to follow any other
+          person on the fediverse, regardless of where their account is hosted.
+        </p>
+
+        <Field>
+          <FieldLabel required htmlFor="email">
+            Email
+          </FieldLabel>
           <Input
             placeholder="Email"
             id="email"
@@ -609,12 +620,12 @@ function SignupForm({
             autoCorrect="off"
             spellCheck={false}
           />
-        </div>
+        </Field>
 
-        <div className="flex flex-col gap-1">
-          <label className="text-muted-foreground text-sm" htmlFor="username">
+        <Field>
+          <FieldLabel required htmlFor="username">
             Username
-          </label>
+          </FieldLabel>
           <div className="flex gap-2">
             <Input
               placeholder="Username"
@@ -629,12 +640,12 @@ function SignupForm({
             />
             <InstanceSelect instance={instance} setInstance={setInstance} />
           </div>
-        </div>
+        </Field>
 
-        <div className="flex flex-col gap-1">
-          <label className="text-muted-foreground text-sm" htmlFor="password">
+        <Field>
+          <FieldLabel required htmlFor="password">
             Password
-          </label>
+          </FieldLabel>
           <Input
             placeholder="Enter password"
             type="password"
@@ -647,14 +658,9 @@ function SignupForm({
             spellCheck={false}
             required
           />
-        </div>
-
-        <div className="flex flex-col gap-1">
-          <label className="text-muted-foreground text-sm">
-            Verify Password
-          </label>
           <Input
-            placeholder="Verify password"
+            wrapperClassName="mt-1"
+            placeholder="Confirm password"
             type="password"
             id="password"
             defaultValue={verifyPassword}
@@ -665,44 +671,56 @@ function SignupForm({
             spellCheck={false}
             required
           />
-        </div>
+        </Field>
 
         {captcha.isPending && <LuLoaderCircle className="animate-spin" />}
 
         {captcha.data && (
-          <div className="flex flex-row gap-4">
-            <div className="flex flex-col justify-around items-center p-2">
-              <button onClick={() => captcha.refetch()} type="button">
-                <MdOutlineRefresh size={24} />
-              </button>
+          <Field className="bg-secondary p-3 rounded-md">
+            <FieldLabel required>Captcha</FieldLabel>
+            <div className="flex flex-row gap-4">
+              <Input
+                wrapperClassName="bg-background"
+                className="self-center"
+                placeholder="Captcha answer"
+                value={captchaAnswer}
+                onChange={(e) => setCaptchaAnswer(e.target.value)}
+              />
 
-              <AudioPlayButton src={captcha.data?.audioUrl} />
+              <div className="flex flex-col justify-around items-center p-2">
+                <button onClick={() => captcha.refetch()} type="button">
+                  <MdOutlineRefresh size={24} />
+                </button>
+
+                <AudioPlayButton src={captcha.data?.audioUrl} />
+              </div>
+
+              <img
+                src={`data:image/png;base64,${captcha.data?.imgUrl}`}
+                className="h-28 aspect-video object-contain"
+              />
             </div>
-
-            <img
-              src={`data:image/png;base64,${captcha.data?.imgUrl}`}
-              className="h-28 aspect-video object-contain"
-            />
-
-            <Input
-              className="self-center"
-              value={captchaAnswer}
-              onChange={(e) => setCaptchaAnswer(e.target.value)}
-            />
-          </div>
+          </Field>
         )}
 
         {applicationQuestion && (
-          <MarkdownRenderer markdown={applicationQuestion} />
+          <>
+            <div className="bg-amber-100 text-amber-800 border-amber-800 border p-2 rounded-md">
+              To join this server, you need to fill out the application below,
+              and wait to be accepted.
+            </div>
+            <MarkdownRenderer markdown={applicationQuestion} />
+          </>
         )}
 
         <Textarea
           value={answer}
           onChange={(e) => setAnswer(e.target.value)}
           required
+          placeholder="Application answer"
         />
 
-        <Button type="submit" className="mx-auto">
+        <Button type="submit">
           Sign up
           {register.isPending && <LuLoaderCircle className="animate-spin" />}
         </Button>

--- a/src/features/auth.tsx
+++ b/src/features/auth.tsx
@@ -225,14 +225,12 @@ function useAuthSite({
 function InstanceSelectionPage({
   instance,
   setInstance,
-  software,
-  setSoftware,
 }: {
   instance: SelectedInstance;
   setInstance: (newInstance: string) => void;
-  software: Software;
-  setSoftware: (software: Software) => void;
 }) {
+  const [software, setSoftware] = useState<Software | "all">("all");
+
   const [search, setSearch] = useState("");
   const searchUrl = useMemo(() => {
     try {
@@ -273,7 +271,8 @@ function InstanceSelectionPage({
       } catch {}
     }
     return _.uniqBy(output, ({ host }) => host).filter(
-      (item) => !item.software || item.software === software,
+      (item) =>
+        software === "all" || !item.software || item.software === software,
     );
   }, [instances.data, site.data, software]);
 
@@ -286,7 +285,7 @@ function InstanceSelectionPage({
       (acc, crnt) => acc + (crnt.software === "piefed" ? 1 : 0),
       0,
     );
-    return { lemmy, piefed };
+    return { lemmy, piefed, all: _.sum(_.compact([lemmy, piefed])) };
   }, [instances.data]);
 
   const sortedInstances =
@@ -320,9 +319,12 @@ function InstanceSelectionPage({
           type="single"
           variant="outline"
           size="sm"
-          value={software}
+          value={software ?? "all"}
           onValueChange={(val) => val && setSoftware(val as Software)}
         >
+          <ToggleGroupItem value="all" data-testid="auth-filter-lemmy">
+            All ({counts.all})
+          </ToggleGroupItem>
           <ToggleGroupItem value="lemmy" data-testid="auth-filter-lemmy">
             Lemmy ({counts.lemmy})
           </ToggleGroupItem>
@@ -807,10 +809,6 @@ function AuthModal({
   const [instance, setInstance] = useInstanceState();
   const modal = useRef<HTMLIonModalElement>(null);
 
-  const [software, setSoftware] = useState<Software>(
-    _.sample([Software.LEMMY, Software.PIEFED]),
-  );
-
   const resetForm = () => {
     setStep(INIT_STEP);
   };
@@ -876,8 +874,6 @@ function AuthModal({
               setInstance(val);
               setStep("login");
             }}
-            software={software}
-            setSoftware={setSoftware}
           />
         )}
 

--- a/src/features/auth.tsx
+++ b/src/features/auth.tsx
@@ -813,6 +813,9 @@ function AuthModal({
     setStep(INIT_STEP);
   };
 
+  const canGoBack =
+    step !== "instance-selection" && !env.REACT_APP_LOCK_TO_DEFAULT_INSTANCE;
+
   return (
     <IonModal
       isOpen={open}
@@ -825,11 +828,7 @@ function AuthModal({
           <ToolbarButtons side="left">
             <IonButton
               className="size-5"
-              data-testid={
-                step !== "instance-selection"
-                  ? "auth-change-instance"
-                  : "auth-close"
-              }
+              data-testid={canGoBack ? "auth-change-instance" : "auth-close"}
               onClick={() => {
                 if (
                   step !== "instance-selection" &&
@@ -841,8 +840,7 @@ function AuthModal({
                 }
               }}
             >
-              {step !== "instance-selection" &&
-              !env.REACT_APP_LOCK_TO_DEFAULT_INSTANCE ? (
+              {canGoBack ? (
                 <ChevronLeft
                   className="-ml-1"
                   aria-label="Back to instance selection"

--- a/src/features/auth.tsx
+++ b/src/features/auth.tsx
@@ -56,7 +56,7 @@ import { ChevronLeft, Spinner, X } from "@/src/components/icons";
 import { AuthContext } from "../hooks/use-require-auth";
 import { Field, FieldLabel } from "../components/ui/field";
 import { useQueryToast } from "../hooks/use-query-toast";
-import { getFirstZodIssue } from "../lib/utils";
+import { getFirstZodIssue } from "../lib/zod";
 
 function LegalNotice({ instance }: { instance: SelectedInstance }) {
   return (

--- a/src/features/auth.tsx
+++ b/src/features/auth.tsx
@@ -109,19 +109,26 @@ const AudioPlayButton = ({ src }: { src: string }) => {
   const audioRef = useRef(new Audio(`data:audio/wav;base64,${src}`));
 
   useEffect(() => {
+    audioRef.current.pause();
+    audioRef.current.src = `data:audio/wav;base64,${src}`;
+    audioRef.current.load();
+    setPlaying(false);
+  }, [src]);
+
+  useEffect(() => {
     const start = () => setPlaying(true);
     const stop = () => setPlaying(false);
 
-    const current = audioRef.current;
+    const audio = audioRef.current;
 
-    current.addEventListener("play", start);
-    current.addEventListener("ended", stop);
-    current.addEventListener("pause", stop);
+    audio.addEventListener("play", start);
+    audio.addEventListener("ended", stop);
+    audio.addEventListener("pause", stop);
 
     return () => {
-      current.removeEventListener("play", start);
-      current.removeEventListener("ended", stop);
-      current.removeEventListener("pause", stop);
+      audio.removeEventListener("play", start);
+      audio.removeEventListener("ended", stop);
+      audio.removeEventListener("pause", stop);
     };
   }, []);
 
@@ -135,9 +142,9 @@ const AudioPlayButton = ({ src }: { src: string }) => {
   };
 
   return (
-    <button type="button" onClick={handlePlay}>
+    <Button size="icon" variant="outline" type="button" onClick={handlePlay}>
       {playing ? <FaPause /> : <FaPlay />}
-    </button>
+    </Button>
   );
 };
 
@@ -676,30 +683,38 @@ function SignupForm({
         {captcha.isPending && <LuLoaderCircle className="animate-spin" />}
 
         {captcha.data && (
-          <Field className="bg-secondary p-3 rounded-md">
-            <FieldLabel required>Captcha</FieldLabel>
-            <div className="flex flex-row gap-4">
+          <Field className="bg-secondary p-3 rounded-md flex flex-row gap-4 justify-between">
+            <div className="flex flex-col justify-between">
+              <FieldLabel required htmlFor="captcha">
+                Captcha
+              </FieldLabel>
               <Input
+                id="captcha"
                 wrapperClassName="bg-background"
                 className="self-center"
                 placeholder="Captcha answer"
                 value={captchaAnswer}
                 onChange={(e) => setCaptchaAnswer(e.target.value)}
               />
-
-              <div className="flex flex-col justify-around items-center p-2">
-                <button onClick={() => captcha.refetch()} type="button">
-                  <MdOutlineRefresh size={24} />
-                </button>
-
-                <AudioPlayButton src={captcha.data?.audioUrl} />
-              </div>
-
-              <img
-                src={`data:image/png;base64,${captcha.data?.imgUrl}`}
-                className="h-28 aspect-video object-contain"
-              />
             </div>
+
+            <div className="flex flex-col justify-around items-center p-2">
+              <Button
+                size="icon"
+                variant="outline"
+                onClick={() => captcha.refetch()}
+                type="button"
+              >
+                <MdOutlineRefresh size={24} />
+              </Button>
+
+              <AudioPlayButton src={captcha.data?.audioUrl} />
+            </div>
+
+            <img
+              src={`data:image/png;base64,${captcha.data?.imgUrl}`}
+              className="h-28 aspect-video object-contain"
+            />
           </Field>
         )}
 

--- a/src/features/auth.tsx
+++ b/src/features/auth.tsx
@@ -55,6 +55,8 @@ import { ToolbarTitle } from "../components/toolbar/toolbar-title";
 import { ChevronLeft, Spinner, X } from "@/src/components/icons";
 import { AuthContext } from "../hooks/use-require-auth";
 import { Field, FieldLabel } from "../components/ui/field";
+import { useQueryToast } from "../hooks/use-query-toast";
+import z from "zod";
 
 function LegalNotice({ instance }: { instance: SelectedInstance }) {
   return (
@@ -250,6 +252,23 @@ function InstanceSelectionPage({
       retry: false,
     },
   );
+
+  const error = (() => {
+    if (site.error instanceof z.ZodError) {
+      const issue = site.error.issues[0];
+      if (issue) {
+        return _.compact([
+          issue.message,
+          "received" in issue ? `"${issue.received}"` : null,
+        ]).join(": ");
+      }
+    }
+    return undefined;
+  })();
+
+  useQueryToast(site, {
+    error,
+  });
 
   const data = useMemo(() => {
     const output = [...(instances.data ?? [])];
@@ -799,7 +818,6 @@ function AuthModal({
   );
 
   const [instance, setInstance] = useInstanceState();
-  console.log(step, instance);
   const modal = useRef<HTMLIonModalElement>(null);
 
   const [software, setSoftware] = useState<Software>(

--- a/src/features/auth.tsx
+++ b/src/features/auth.tsx
@@ -725,8 +725,8 @@ function SignupForm({
         {captcha.isPending && <LuLoaderCircle className="animate-spin" />}
 
         {captcha.data && (
-          <Field className="bg-secondary p-3 rounded-md flex flex-row gap-4 justify-between">
-            <div className="flex flex-col justify-between">
+          <Field className="bg-secondary p-3 rounded-md flex md:flex-row gap-4 justify-between">
+            <div className="flex flex-col gap-3 justify-between">
               <FieldLabel required htmlFor="captcha">
                 Captcha
               </FieldLabel>
@@ -740,23 +740,25 @@ function SignupForm({
               />
             </div>
 
-            <div className="flex flex-col justify-around items-center p-2">
-              <Button
-                size="icon"
-                variant="outline"
-                onClick={() => captcha.refetch()}
-                type="button"
-              >
-                <MdOutlineRefresh size={24} />
-              </Button>
+            <div className="md:contents flex flex-row gap-3">
+              <div className="flex flex-col justify-around items-center p-2">
+                <Button
+                  size="icon"
+                  variant="outline"
+                  onClick={() => captcha.refetch()}
+                  type="button"
+                >
+                  <MdOutlineRefresh size={24} />
+                </Button>
 
-              <AudioPlayButton src={captcha.data?.audioUrl} />
+                <AudioPlayButton src={captcha.data?.audioUrl} />
+              </div>
+
+              <img
+                src={`data:image/png;base64,${captcha.data?.imgUrl}`}
+                className="h-28 aspect-video object-contain"
+              />
             </div>
-
-            <img
-              src={`data:image/png;base64,${captcha.data?.imgUrl}`}
-              className="h-28 aspect-video object-contain"
-            />
           </Field>
         )}
 

--- a/src/features/auth.tsx
+++ b/src/features/auth.tsx
@@ -1,8 +1,6 @@
 import {
-  createContext,
   FormEvent,
   useCallback,
-  useContext,
   useEffect,
   useMemo,
   useRef,
@@ -10,15 +8,11 @@ import {
 } from "react";
 import { getAccountSite, useAuth } from "@/src/stores/auth";
 import {
-  // eslint-disable-next-line local/no-query-hooks-in-components -- auth-context is a session bootstrapper, not a UI component. It owns the auth lifecycle (login, register, captcha, site config) and is the only appropriate place to fetch these.
   useCaptchaQuery,
-  // eslint-disable-next-line local/no-query-hooks-in-components -- same as above
   useInstancesQuery,
   useLoginMutation,
-  // eslint-disable-next-line local/no-query-hooks-in-components -- same as above
   useRefreshAuthQuery,
   useRegisterMutation,
-  // eslint-disable-next-line local/no-query-hooks-in-components -- same as above
   useSiteQuery,
 } from "../queries";
 import fuzzysort from "fuzzysort";
@@ -30,35 +24,37 @@ import {
   IonModal,
   IonToolbar,
 } from "@ionic/react";
-import { Input } from "./ui/input";
-import { Button } from "./ui/button";
+import { Input } from "../components/ui/input";
+import { Button } from "../components/ui/button";
 import {
   InputOTP,
   InputOTPGroup,
   InputOTPSeparator,
   InputOTPSlot,
-} from "./ui/input-otp";
+} from "../components/ui/input-otp";
 import { LuLoaderCircle } from "react-icons/lu";
 import { FaPlay, FaPause } from "react-icons/fa";
 import { MdOutlineRefresh } from "react-icons/md";
-import { Textarea } from "./ui/textarea";
-import { MarkdownRenderer } from "./markdown/renderer";
+import { Textarea } from "../components/ui/textarea";
+import { MarkdownRenderer } from "../components/markdown/renderer";
 import { env } from "../env";
-import { ToggleGroup, ToggleGroupItem } from "./ui/toggle-group";
+import { ToggleGroup, ToggleGroupItem } from "../components/ui/toggle-group";
 import { cn } from "../lib/utils";
 import { normalizeInstance } from "../normalize-instance";
-import { ToolbarButtons } from "./toolbar/toolbar-buttons";
+import { ToolbarButtons } from "../components/toolbar/toolbar-buttons";
 import {
   Select,
   SelectContent,
   SelectTrigger,
   SelectItem,
   SelectValue,
-} from "./ui/select";
-import { Avatar, AvatarFallback, AvatarImage } from "./ui/avatar";
+} from "../components/ui/select";
+import { Avatar, AvatarFallback, AvatarImage } from "../components/ui/avatar";
 import { Software } from "../apis/api-blueprint";
-import { ToolbarTitle } from "./toolbar/toolbar-title";
+import { ToolbarTitle } from "../components/toolbar/toolbar-title";
 import { ChevronLeft, Spinner, X } from "@/src/components/icons";
+import { AuthContext } from "../hooks/use-require-auth";
+import { Field, FieldLabel } from "../components/ui/field";
 
 function LegalNotice({ instance }: { instance: SelectedInstance }) {
   return (
@@ -145,12 +141,6 @@ const AudioPlayButton = ({ src }: { src: string }) => {
   );
 };
 
-const Context = createContext<{
-  authenticate: (config?: { addAccount?: boolean }) => Promise<void>;
-}>({
-  authenticate: () => Promise.reject(),
-});
-
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const refresh = useRefreshAuthQuery();
 
@@ -195,7 +185,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }, [refresh.isSuccess, isLoggedIn, site, authenticate]);
 
   return (
-    <Context.Provider
+    <AuthContext.Provider
       value={{
         authenticate,
       }}
@@ -207,12 +197,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         onSuccess={() => promise?.resolve()}
         addAccount={promise?.addAccount === true}
       />
-    </Context.Provider>
+    </AuthContext.Provider>
   );
-}
-
-export function useRequireAuth() {
-  return useContext(Context).authenticate;
 }
 
 function useAuthSite({
@@ -418,110 +404,119 @@ function LoginForm({
   return (
     <form
       onSubmit={submitLogin}
-      className="gap-4 flex flex-col p-4 overflow-y-auto ion-content-scroll-host h-full overflow-x-hidden"
+      className="gap-4 flex flex-col p-6 overflow-y-auto ion-content-scroll-host h-full overflow-x-hidden"
       data-testid="login-form"
     >
-      <div className="flex flex-col gap-1">
-        <label className="text-muted-foreground text-sm">Username</label>
-        <div className="flex gap-2">
+      <div className="flex flex-col gap-5">
+        <span className="text-2xl font-bold">Login to {instance.baseurl}</span>
+
+        <p>
+          Login with your <b>{instance.baseurl}</b> credentials. If your account
+          is hosted on a different server, you must change instance before
+          loggin in.
+        </p>
+
+        <Field>
+          <FieldLabel required>Username</FieldLabel>
+          <div className="flex gap-2">
+            <Input
+              placeholder="Username"
+              id="username"
+              defaultValue={userName}
+              onChange={(e) => setUsername(e.target.value)}
+              autoComplete="username"
+              autoCapitalize="none"
+              autoCorrect="off"
+              spellCheck={false}
+              required
+            />
+            <InstanceSelect instance={instance} setInstance={setInstance} />
+          </div>
+        </Field>
+
+        <Field>
+          <FieldLabel required>Password</FieldLabel>
           <Input
-            placeholder="Username"
-            id="username"
-            defaultValue={userName}
-            onChange={(e) => setUsername(e.target.value)}
-            autoComplete="username"
+            placeholder="Enter password"
+            type="password"
+            id="password"
+            defaultValue={password}
+            onChange={(e) => setPassword(e.target.value)}
+            autoComplete="current-password"
             autoCapitalize="none"
             autoCorrect="off"
             spellCheck={false}
             required
           />
-          <InstanceSelect instance={instance} setInstance={setInstance} />
-        </div>
-      </div>
+        </Field>
 
-      <div className="flex flex-col gap-1">
-        <label className="text-muted-foreground text-sm">Password</label>
-        <Input
-          placeholder="Enter password"
-          type="password"
-          id="password"
-          defaultValue={password}
-          onChange={(e) => setPassword(e.target.value)}
-          autoComplete="current-password"
-          autoCapitalize="none"
-          autoCorrect="off"
-          spellCheck={false}
-          required
-        />
-      </div>
+        {(login.needsMfa || _.isString(mfaToken)) && (
+          <InputOTP
+            data-testid="otp-input"
+            maxLength={6}
+            defaultValue={mfaToken}
+            onChange={(newMfa) => {
+              setMfaToken(newMfa);
+              if (newMfa.length === 6) {
+                mutateLogin(newMfa);
+              }
+            }}
+            autoComplete="one-time-code"
+            autoCapitalize="none"
+            autoCorrect="off"
+            spellCheck={false}
+            required
+          >
+            <InputOTPGroup>
+              <InputOTPSlot index={0} />
+              <InputOTPSlot index={1} />
+              <InputOTPSlot index={2} />
+            </InputOTPGroup>
+            <InputOTPSeparator />
+            <InputOTPGroup>
+              <InputOTPSlot index={3} />
+              <InputOTPSlot index={4} />
+              <InputOTPSlot index={5} />
+            </InputOTPGroup>
+          </InputOTP>
+        )}
 
-      {(login.needsMfa || _.isString(mfaToken)) && (
-        <InputOTP
-          data-testid="otp-input"
-          maxLength={6}
-          defaultValue={mfaToken}
-          onChange={(newMfa) => {
-            setMfaToken(newMfa);
-            if (newMfa.length === 6) {
-              mutateLogin(newMfa);
-            }
-          }}
-          autoComplete="one-time-code"
-          autoCapitalize="none"
-          autoCorrect="off"
-          spellCheck={false}
-          required
-        >
-          <InputOTPGroup>
-            <InputOTPSlot index={0} />
-            <InputOTPSlot index={1} />
-            <InputOTPSlot index={2} />
-          </InputOTPGroup>
-          <InputOTPSeparator />
-          <InputOTPGroup>
-            <InputOTPSlot index={3} />
-            <InputOTPSlot index={4} />
-            <InputOTPSlot index={5} />
-          </InputOTPGroup>
-        </InputOTP>
-      )}
-
-      <Button type="submit" className="mx-auto">
-        Sign In
-        {login.isPending && <LuLoaderCircle className="animate-spin" />}
-      </Button>
-
-      <span className="mx-auto">
-        Need an account?
-        <Button type="button" variant="link" onClick={handleSignup}>
-          Sign up
+        <Button type="submit" className="">
+          Sign In
+          {login.isPending && <LuLoaderCircle className="animate-spin" />}
         </Button>
-      </span>
 
-      {site.data?.site.privateInstance === false && (
-        <Button
-          type="button"
-          className="mx-auto"
-          variant="ghost"
-          onClick={() => {
-            if (addAccount) {
-              addAccountFn({
-                instance: instance.url,
-              });
-            } else {
-              updateSelectedAccount({
-                instance: instance.url,
-              });
-            }
-            // setInstance(null);
-            onClose();
-          }}
-        >
-          Continue as Guest
-        </Button>
-      )}
+        <span className="mx-auto">
+          <Button type="button" variant="link" onClick={handleSignup}>
+            Sign up
+          </Button>
 
-      <LegalNotice instance={instance} />
+          {site.data?.site.privateInstance === false && (
+            <Button
+              type="button"
+              className="mx-auto"
+              variant="link"
+              onClick={() => {
+                if (addAccount) {
+                  addAccountFn({
+                    instance: instance.url,
+                  });
+                } else {
+                  updateSelectedAccount({
+                    instance: instance.url,
+                  });
+                }
+                // setInstance(null);
+                onClose();
+              }}
+            >
+              Continue as Guest
+            </Button>
+          )}
+        </span>
+
+        <LegalNotice instance={instance} />
+      </div>
     </form>
   );
 }
@@ -753,9 +748,7 @@ function useInstanceState() {
   return [_instance, setInstanceLocal] as const;
 }
 
-const INIT_STEP = env.REACT_APP_LOCK_TO_DEFAULT_INSTANCE
-  ? "login"
-  : "instance-selection";
+const INIT_STEP = "login";
 
 function AuthModal({
   open,
@@ -773,6 +766,7 @@ function AuthModal({
   );
 
   const [instance, setInstance] = useInstanceState();
+  console.log(step, instance);
   const modal = useRef<HTMLIonModalElement>(null);
 
   const [software, setSoftware] = useState<Software>(
@@ -819,7 +813,7 @@ function AuthModal({
             <ToolbarTitle numRightIcons={0}>
               {step === "instance-selection"
                 ? "Chose an instance"
-                : instance.baseurl}
+                : "Change instance"}
             </ToolbarTitle>
           </ToolbarButtons>
           {step !== "instance-selection" && (

--- a/src/features/auth.tsx
+++ b/src/features/auth.tsx
@@ -56,7 +56,7 @@ import { ChevronLeft, Spinner, X } from "@/src/components/icons";
 import { AuthContext } from "../hooks/use-require-auth";
 import { Field, FieldLabel } from "../components/ui/field";
 import { useQueryToast } from "../hooks/use-query-toast";
-import z from "zod";
+import { getFirstZodIssue } from "../lib/utils";
 
 function LegalNotice({ instance }: { instance: SelectedInstance }) {
   return (
@@ -253,21 +253,8 @@ function InstanceSelectionPage({
     },
   );
 
-  const error = (() => {
-    if (site.error instanceof z.ZodError) {
-      const issue = site.error.issues[0];
-      if (issue) {
-        return _.compact([
-          issue.message,
-          "received" in issue ? `"${issue.received}"` : null,
-        ]).join(": ");
-      }
-    }
-    return undefined;
-  })();
-
   useQueryToast(site, {
-    error,
+    error: getFirstZodIssue(site.error)?.message,
   });
 
   const data = useMemo(() => {

--- a/src/features/auth.tsx
+++ b/src/features/auth.tsx
@@ -89,7 +89,7 @@ function InstanceSelect({
 }) {
   const options = useMemo(() => {
     return env.defaultInstances.map((i) => {
-      let label = i;
+      let label: string = i;
 
       try {
         const url = new URL(i);
@@ -262,7 +262,7 @@ function InstanceSelectionPage({
   }, [search]);
 
   const instances = useInstancesQuery();
-  const suggestions = useLoginSuggestions(instance.url);
+  const suggestions = useAuth((s) => s.knownAccounts);
   const keyedSuggestions = useMemo(
     () => _.keyBy(suggestions, "instance"),
     [suggestions],
@@ -380,7 +380,7 @@ function InstanceSelectionPage({
             <span className="text-sm text-muted-foreground">
               {i.description}
             </span>
-            {keyedSuggestions[i.host] && (
+            {keyedSuggestions[i.url] && (
               <Badge variant="brand">Previously used</Badge>
             )}
           </div>

--- a/src/features/auth.tsx
+++ b/src/features/auth.tsx
@@ -6,7 +6,11 @@ import {
   useRef,
   useState,
 } from "react";
-import { getAccountSite, useAuth } from "@/src/stores/auth";
+import {
+  getAccountSite,
+  useAuth,
+  useLoginSuggestions,
+} from "@/src/stores/auth";
 import {
   useCaptchaQuery,
   useInstancesQuery,
@@ -57,6 +61,7 @@ import { AuthContext } from "../hooks/use-require-auth";
 import { Field, FieldLabel } from "../components/ui/field";
 import { useQueryToast } from "../hooks/use-query-toast";
 import { getFirstZodIssue } from "../lib/zod";
+import { Badge } from "../components/ui/badge";
 
 function LegalNotice({ instance }: { instance: SelectedInstance }) {
   return (
@@ -241,6 +246,11 @@ function InstanceSelectionPage({
   }, [search]);
 
   const instances = useInstancesQuery();
+  const suggestions = useLoginSuggestions(instance.url);
+  const keyedSuggestions = useMemo(
+    () => _.keyBy(suggestions, "instance"),
+    [suggestions],
+  );
 
   const site = useSiteQuery(
     {
@@ -349,11 +359,14 @@ function InstanceSelectionPage({
             <AvatarImage src={i.icon} />
             <AvatarFallback>{i.host[0]}</AvatarFallback>
           </Avatar>
-          <div className="flex flex-col">
+          <div className="flex flex-col gap-1.5 leading-tight">
             <span>{i.host}</span>
             <span className="text-sm text-muted-foreground">
               {i.description}
             </span>
+            {keyedSuggestions[i.host] && (
+              <Badge variant="brand">Previously used</Badge>
+            )}
           </div>
         </button>
       ))}
@@ -379,7 +392,12 @@ function LoginForm({
   const updateSelectedAccount = useAuth((a) => a.updateSelectedAccount);
   const addAccountFn = useAuth((a) => a.addAccount);
 
-  const [userName, setUsername] = useState("");
+  const suggestions = useLoginSuggestions(instance.url);
+  const suggestedUsername =
+    suggestions.length === 1 ? suggestions[0]?.username.split("@")[0] : null;
+
+  const [_username, setUsername] = useState<string | null>();
+  const username = _username ?? suggestedUsername ?? "";
   const [password, setPassword] = useState("");
   const [mfaToken, setMfaToken] = useState<string>();
 
@@ -401,7 +419,7 @@ function LoginForm({
   const mutateLogin = (newMfaToken = mfaToken) => {
     login
       .mutateAsync({
-        username: userName,
+        username: username,
         password: password,
         mfaCode: newMfaToken,
       })
@@ -437,7 +455,7 @@ function LoginForm({
             <Input
               placeholder="Username"
               id="username"
-              defaultValue={userName}
+              defaultValue={username}
               onChange={(e) => setUsername(e.target.value)}
               autoComplete="username"
               autoCapitalize="none"

--- a/src/features/auth.tsx
+++ b/src/features/auth.tsx
@@ -66,7 +66,7 @@ import { Badge } from "../components/ui/badge";
 function LegalNotice({ instance }: { instance: SelectedInstance }) {
   return (
     <span className="mx-auto text-muted-foreground text-sm text-center">
-      By signing up you agree to {instance.baseurl} and{" "}
+      By signing up you agree to {instance.host} and{" "}
       <a
         className="underline"
         href="https://blorpblorp.xyz/terms"
@@ -87,6 +87,22 @@ function InstanceSelect({
   instance: SelectedInstance;
   setInstance: (val: string) => void;
 }) {
+  const options = useMemo(() => {
+    return env.defaultInstances.map((i) => {
+      let label = i;
+
+      try {
+        const url = new URL(i);
+        label = `@${url.host}`;
+      } catch {}
+
+      return {
+        value: i,
+        label,
+      };
+    });
+  }, []);
+
   if (
     !env.REACT_APP_LOCK_TO_DEFAULT_INSTANCE ||
     env.defaultInstances.length <= 1
@@ -97,13 +113,13 @@ function InstanceSelect({
   return (
     <Select value={instance.url} onValueChange={(val) => setInstance(val)}>
       <SelectTrigger className="w-64">
-        <SelectValue>@{instance.baseurl}</SelectValue>
+        <SelectValue>@{instance.host}</SelectValue>
       </SelectTrigger>
       <SelectContent align="end">
         {/* TODO: Render @instance instead of full url */}
-        {env.defaultInstances.map((i) => (
-          <SelectItem key={i} value={i}>
-            {i}
+        {options.map(({ value, label }) => (
+          <SelectItem key={value} value={value}>
+            {label}
           </SelectItem>
         ))}
       </SelectContent>
@@ -223,7 +239,7 @@ function useAuthSite({
   instance: SelectedInstance;
 }) {
   return useSiteQuery({
-    instance: search || instance.baseurl || env.defaultInstance,
+    instance: search || instance.host || env.defaultInstance,
   });
 }
 
@@ -254,7 +270,7 @@ function InstanceSelectionPage({
 
   const site = useSiteQuery(
     {
-      instance: searchUrl ?? instance.baseurl,
+      instance: searchUrl ?? instance.host,
     },
     {
       retry: false,
@@ -441,12 +457,12 @@ function LoginForm({
       data-testid="login-form"
     >
       <div className="flex flex-col gap-5">
-        <span className="text-2xl font-bold">Login to {instance.baseurl}</span>
+        <span className="text-2xl font-bold">Login to {instance.host}</span>
 
         <p>
-          Login with your <b>{instance.baseurl}</b> credentials. If your account
-          is hosted on a different server, you must change instance before
-          loggin in.
+          Login with your <b>{instance.host}</b> credentials. If your account is
+          hosted on a different server, you must change instance before loggin
+          in.
         </p>
 
         <Field>
@@ -455,7 +471,7 @@ function LoginForm({
             <Input
               placeholder="Username"
               id="username"
-              defaultValue={username}
+              value={username}
               onChange={(e) => setUsername(e.target.value)}
               autoComplete="username"
               autoCapitalize="none"
@@ -473,7 +489,7 @@ function LoginForm({
             placeholder="Enter password"
             type="password"
             id="password"
-            defaultValue={password}
+            value={password}
             onChange={(e) => setPassword(e.target.value)}
             autoComplete="current-password"
             autoCapitalize="none"
@@ -487,7 +503,7 @@ function LoginForm({
           <InputOTP
             data-testid="otp-input"
             maxLength={6}
-            defaultValue={mfaToken}
+            value={mfaToken}
             onChange={(newMfa) => {
               setMfaToken(newMfa);
               if (newMfa.length === 6) {
@@ -631,7 +647,7 @@ function SignupForm({
         data-testid="signup-form"
       >
         <span className="text-2xl font-bold">
-          Let's get you set up on {instance.baseurl}.
+          Let's get you set up on {instance.host}.
         </span>
 
         <p>
@@ -774,12 +790,12 @@ function SignupForm({
 
 const DEFAULT_INSTACE = {
   url: env.defaultInstance,
-  baseurl: new URL(env.defaultInstance).host,
+  host: new URL(env.defaultInstance).host,
 };
 
 type SelectedInstance = {
   url: string;
-  baseurl: string;
+  host: string;
 };
 
 function useInstanceState() {
@@ -790,13 +806,13 @@ function useInstanceState() {
       _setInstanceLocal(DEFAULT_INSTACE);
       return;
     }
-    let baseurl: string | undefined = undefined;
+    let host: string | undefined = undefined;
     try {
-      baseurl = new URL(url).host;
+      host = new URL(url).host;
     } catch {}
     _setInstanceLocal({
       url,
-      baseurl: baseurl ?? url,
+      host: host ?? url,
     });
   };
 

--- a/src/features/post.tsx
+++ b/src/features/post.tsx
@@ -35,6 +35,7 @@ import {
   useIonPageElement,
   useMedia,
   useTheme,
+  useRequireAuth,
 } from "../hooks";
 import { Page } from "../components/page";
 import { CommentSkeleton } from "../components/comments/comment-skeleton";
@@ -48,7 +49,6 @@ import { SearchBar } from "./search/search-bar";
 import { useCommentsByPaths } from "../stores/comments";
 import { useCommunityFromStore } from "../stores/communities";
 import { useQueryToast } from "../hooks/use-query-toast";
-import { useRequireAuth } from "../components/auth-context";
 
 function SafeAreaBottom() {
   return <div className="h-safe-area-bottom bg-background" />;

--- a/src/features/settings/settings-screen.tsx
+++ b/src/features/settings/settings-screen.tsx
@@ -19,7 +19,6 @@ import {
   useAuth,
 } from "@/src/stores/auth";
 import { Badge } from "@/src/components/ui/badge";
-import { useRequireAuth } from "@/src/components/auth-context";
 import { ContentGutters } from "@/src/components/gutters";
 import _ from "lodash";
 import { Logo } from "@/src/components/logo";
@@ -32,7 +31,11 @@ import { PersonCard } from "@/src/components/person/person-card";
 import { openUrl } from "@/src/lib/linking";
 import { resolveRoute } from "@/src/routing";
 import { SectionItem, Section } from "./shared-components";
-import { useConfirmationAlert, useIsActiveRoute } from "@/src/hooks/index";
+import {
+  useConfirmationAlert,
+  useIsActiveRoute,
+  useRequireAuth,
+} from "@/src/hooks/index";
 import { DebouncedInput } from "@/src/components/debounced-input";
 import { FiChevronRight } from "react-icons/fi";
 import { ToolbarTitle } from "@/src/components/toolbar/toolbar-title";

--- a/src/hooks/alerts.ts
+++ b/src/hooks/alerts.ts
@@ -1,0 +1,130 @@
+import type z from "zod";
+import { AlertInput, useIonAlert } from "@ionic/react";
+import { Deferred } from "../lib/deferred";
+
+export function useSelectAlert() {
+  const [alrt] = useIonAlert();
+  return async <T extends string>({
+    header,
+    message,
+    options,
+    cancelText = "Cancel",
+  }: {
+    header?: string;
+    message?: string;
+    options: { text: string; value: T }[];
+    cancelText?: string;
+  }): Promise<T> => {
+    const deferred = new Deferred<T>();
+    alrt({
+      header,
+      message,
+      buttons: [
+        ...options.map((opt) => ({
+          text: opt.text,
+          handler: () => deferred.resolve(opt.value),
+        })),
+        { text: cancelText, role: "cancel" },
+      ],
+      onDidDismiss: (e) => {
+        if (e.detail.role === "cancel" || e.detail.role === "backdrop") {
+          deferred.reject();
+        }
+      },
+    });
+    return deferred.promise;
+  };
+}
+
+export function useConfirmationAlert() {
+  const [alrt] = useIonAlert();
+
+  return async <Z extends z.AnyZodObject>({
+    header,
+    message,
+    cancelText = "Cancel",
+    confirmText = "OK",
+    danger,
+    // Ionic with crash if you pass undefined
+    // instead of an empty array
+    inputs = [],
+    schema,
+  }: {
+    header?: string;
+    message: string;
+    cancelText?: string;
+    confirmText?: string;
+    danger?: boolean;
+    inputs?: AlertInput[];
+    schema?: Z;
+  }) => {
+    const deferred = new Deferred<z.infer<Z>>();
+    alrt({
+      header,
+      message,
+      inputs,
+      buttons: [
+        {
+          text: cancelText,
+          role: "cancel",
+        },
+        {
+          text: confirmText,
+          role: danger ? "destructive" : "confirm",
+        },
+      ],
+      onDidDismiss: (e) => {
+        if (e.detail.role === "cancel" || e.detail.role === "backdrop") {
+          deferred.reject();
+        } else {
+          try {
+            const data = schema?.parse(e.detail.data.values);
+            deferred.resolve(data);
+          } catch (err) {
+            console.error(err);
+            deferred.reject();
+          }
+        }
+      },
+    });
+    return await deferred.promise;
+  };
+}
+
+export function useInputAlert() {
+  const [alrt] = useIonAlert();
+
+  return async ({
+    header,
+    message,
+    placeholder,
+  }: {
+    header?: string;
+    message?: string;
+    placeholder?: string;
+  }) => {
+    const deferred = new Deferred<string>();
+    alrt({
+      header,
+      message,
+      inputs: [{ placeholder, name: "value" }],
+      buttons: [
+        { text: "Cancel", role: "cancel" },
+        { text: "OK", role: "confirm" },
+      ],
+      onDidDismiss: (e) => {
+        if (e.detail.role === "cancel" || e.detail.role === "backdrop") {
+          deferred.reject();
+        } else {
+          const val = e.detail.data?.values?.value ?? "";
+          if (val) {
+            deferred.resolve(val);
+          } else {
+            deferred.reject();
+          }
+        }
+      },
+    });
+    return await deferred.promise;
+  };
+}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -8,9 +8,6 @@ import {
   useState,
 } from "react";
 import { InAppBrowser } from "@capacitor/inappbrowser";
-import type z from "zod";
-import { AlertInput, useIonAlert } from "@ionic/react";
-import { Deferred } from "../lib/deferred";
 import { useMedia } from "./use-media";
 import _ from "lodash";
 import { useIsActiveRoute } from "./navigation-hooks";
@@ -19,6 +16,7 @@ export * from "./use-tag-user";
 export * from "./nsfw";
 export * from "./use-pathname";
 export * from "./use-require-auth";
+export * from "./alerts";
 export { useMedia } from "./use-media";
 export { useTheme } from "./use-theme";
 export { useUrlSearchState } from "./use-url-search-state";
@@ -72,133 +70,6 @@ export function useIsInAppBrowserOpen() {
     };
   }, []);
   return isOpen;
-}
-
-export function useSelectAlert() {
-  const [alrt] = useIonAlert();
-  return async <T extends string>({
-    header,
-    message,
-    options,
-    cancelText = "Cancel",
-  }: {
-    header?: string;
-    message?: string;
-    options: { text: string; value: T }[];
-    cancelText?: string;
-  }): Promise<T> => {
-    const deferred = new Deferred<T>();
-    alrt({
-      header,
-      message,
-      buttons: [
-        ...options.map((opt) => ({
-          text: opt.text,
-          handler: () => deferred.resolve(opt.value),
-        })),
-        { text: cancelText, role: "cancel" },
-      ],
-      onDidDismiss: (e) => {
-        if (e.detail.role === "cancel" || e.detail.role === "backdrop") {
-          deferred.reject();
-        }
-      },
-    });
-    return deferred.promise;
-  };
-}
-
-export function useConfirmationAlert() {
-  const [alrt] = useIonAlert();
-
-  return async <Z extends z.AnyZodObject>({
-    header,
-    message,
-    cancelText = "Cancel",
-    confirmText = "OK",
-    danger,
-    // Ionic with crash if you pass undefined
-    // instead of an empty array
-    inputs = [],
-    schema,
-  }: {
-    header?: string;
-    message: string;
-    cancelText?: string;
-    confirmText?: string;
-    danger?: boolean;
-    inputs?: AlertInput[];
-    schema?: Z;
-  }) => {
-    const deferred = new Deferred<z.infer<Z>>();
-    alrt({
-      header,
-      message,
-      inputs,
-      buttons: [
-        {
-          text: cancelText,
-          role: "cancel",
-        },
-        {
-          text: confirmText,
-          role: danger ? "destructive" : "confirm",
-        },
-      ],
-      onDidDismiss: (e) => {
-        if (e.detail.role === "cancel" || e.detail.role === "backdrop") {
-          deferred.reject();
-        } else {
-          try {
-            const data = schema?.parse(e.detail.data.values);
-            deferred.resolve(data);
-          } catch (err) {
-            console.error(err);
-            deferred.reject();
-          }
-        }
-      },
-    });
-    return await deferred.promise;
-  };
-}
-
-export function useInputAlert() {
-  const [alrt] = useIonAlert();
-
-  return async ({
-    header,
-    message,
-    placeholder,
-  }: {
-    header?: string;
-    message?: string;
-    placeholder?: string;
-  }) => {
-    const deferred = new Deferred<string>();
-    alrt({
-      header,
-      message,
-      inputs: [{ placeholder, name: "value" }],
-      buttons: [
-        { text: "Cancel", role: "cancel" },
-        { text: "OK", role: "confirm" },
-      ],
-      onDidDismiss: (e) => {
-        if (e.detail.role === "cancel" || e.detail.role === "backdrop") {
-          deferred.reject();
-        } else {
-          const val = e.detail.data?.values?.value ?? "";
-          if (val) {
-            deferred.resolve(val);
-          } else {
-            deferred.reject();
-          }
-        }
-      },
-    });
-    return await deferred.promise;
-  };
 }
 
 /**

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -15,6 +15,10 @@ import { useMedia } from "./use-media";
 import _ from "lodash";
 import { useIsActiveRoute } from "./navigation-hooks";
 
+export * from "./use-tag-user";
+export * from "./nsfw";
+export * from "./use-pathname";
+export * from "./use-require-auth";
 export { useMedia } from "./use-media";
 export { useTheme } from "./use-theme";
 export { useUrlSearchState } from "./use-url-search-state";

--- a/src/hooks/use-query-toast.ts
+++ b/src/hooks/use-query-toast.ts
@@ -22,6 +22,7 @@ export function useQueryToast(
         if (errorMsg) {
           toastId.current = toast.error(errorMsg, {
             id: toastId.current,
+            duration: 5_000,
           });
         } else {
           toast.dismiss(toastId.current);
@@ -32,6 +33,7 @@ export function useQueryToast(
         if (successMsg) {
           toastId.current = toast.success(successMsg, {
             id: toastId.current,
+            duration: 5_000,
           });
         } else {
           toast.dismiss(toastId.current);
@@ -42,6 +44,7 @@ export function useQueryToast(
         if (pendingMsg) {
           toastId.current = toast.loading(pendingMsg, {
             id: toastId.current,
+            duration: 5_000,
           });
         } else {
           toast.dismiss(toastId.current);

--- a/src/hooks/use-require-auth.ts
+++ b/src/hooks/use-require-auth.ts
@@ -1,0 +1,11 @@
+import { useContext, createContext } from "react";
+
+export const AuthContext = createContext<{
+  authenticate: (config?: { addAccount?: boolean }) => Promise<void>;
+}>({
+  authenticate: () => Promise.reject(),
+});
+
+export function useRequireAuth() {
+  return useContext(AuthContext).authenticate;
+}

--- a/src/hooks/use-tag-user.ts
+++ b/src/hooks/use-tag-user.ts
@@ -1,7 +1,6 @@
-// eslint-disable-next-line no-restricted-imports -- TODO: import from specific file
-import { useConfirmationAlert } from ".";
 import { useTagUserStore } from "../stores/user-tags";
 import z from "zod";
+import { useConfirmationAlert } from "./alerts";
 
 export function useTagUser() {
   const setUserTag = useTagUserStore((s) => s.setUserTag);

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -101,6 +101,10 @@ export const assert = import.meta.env.DEV
     }
   : () => {};
 
+export function getFirstZodIssue(error: Error | null | undefined) {
+  return error instanceof z.ZodError ? error.issues[0] : undefined;
+}
+
 export function ensureValue<T>(
   options: T[] | readonly T[] | null | undefined,
   value: T,

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -101,10 +101,6 @@ export const assert = import.meta.env.DEV
     }
   : () => {};
 
-export function getFirstZodIssue(error: Error | null | undefined) {
-  return error instanceof z.ZodError ? error.issues[0] : undefined;
-}
-
 export function ensureValue<T>(
   options: T[] | readonly T[] | null | undefined,
   value: T,

--- a/src/lib/zod.test.ts
+++ b/src/lib/zod.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "vitest";
+import { z } from "zod";
+import { getFirstZodIssue, zodEnumMessage } from "./zod";
+
+describe("zodEnumMessage", () => {
+  const schema = z.object({
+    name: z.enum(
+      ["lemmy", "piefed"],
+      zodEnumMessage`Unsupported software: ${(i) => i.received}`,
+    ),
+  });
+
+  test("interpolates received value for invalid enum", () => {
+    const result = schema.safeParse({ name: "mastodon" });
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.message).toBe(
+      "Unsupported software: mastodon",
+    );
+  });
+
+  test("falls back to static string for invalid type", () => {
+    const result = schema.safeParse({ name: 123 });
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.message).toBe("Unsupported software: ");
+  });
+
+  test("works with no interpolations", () => {
+    const staticSchema = z.object({
+      name: z.enum(["a", "b"], zodEnumMessage`Invalid value`),
+    });
+    const result = staticSchema.safeParse({ name: "c" });
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.message).toBe("Invalid value");
+  });
+
+  test("works with multiple interpolations", () => {
+    const multiSchema = z.object({
+      name: z.enum(
+        ["a", "b"],
+        zodEnumMessage`Got ${(i) => i.received}, want ${(i) => i.options.join(" or ")}`,
+      ),
+    });
+    const result = multiSchema.safeParse({ name: "c" });
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.message).toBe("Got c, want a or b");
+  });
+});
+
+describe("getFirstZodIssue", () => {
+  test("returns first issue from a ZodError", () => {
+    const result = z.string().safeParse(123);
+    expect(result.success).toBe(false);
+    const issue = getFirstZodIssue(result.error);
+    expect(issue?.message).toBe("Expected string, received number");
+  });
+
+  test("returns first issue when there are multiple", () => {
+    const result = z
+      .object({ a: z.string(), b: z.string() })
+      .safeParse({ a: 1, b: 2 });
+    expect(result.success).toBe(false);
+    const issue = getFirstZodIssue(result.error);
+    expect(issue?.path).toEqual(["a"]);
+  });
+
+  test.each([
+    ["a plain Error", new Error("oops")],
+    ["null", null],
+    ["undefined", undefined],
+  ])("returns undefined for %s", (_, value) => {
+    expect(getFirstZodIssue(value)).toBeUndefined();
+  });
+});

--- a/src/lib/zod.ts
+++ b/src/lib/zod.ts
@@ -1,0 +1,27 @@
+import { z } from "zod";
+
+type InvalidEnumIssue = Extract<
+  z.ZodIssueOptionalMessage,
+  { code: typeof z.ZodIssueCode.invalid_enum_value }
+>;
+
+export function zodEnumMessage(
+  strings: TemplateStringsArray,
+  ...fns: Array<(issue: InvalidEnumIssue) => string | number>
+) {
+  return {
+    errorMap: (issue: z.ZodIssueOptionalMessage) => ({
+      message:
+        issue.code === z.ZodIssueCode.invalid_enum_value
+          ? strings.reduce<string>(
+              (acc, str, i) => acc + String(fns[i - 1]?.(issue) ?? "") + str,
+              "",
+            )
+          : strings.join(""),
+    }),
+  };
+}
+
+export function getFirstZodIssue(error: Error | null | undefined) {
+  return error instanceof z.ZodError ? error.issues[0] : undefined;
+}

--- a/src/normalize-instance.ts
+++ b/src/normalize-instance.ts
@@ -1,4 +1,8 @@
-export function normalizeInstance(instance: string) {
+export type NormalizedInstance = string & {
+  readonly __brand: "NormalizedInstance";
+};
+
+export function normalizeInstance(instance: string): NormalizedInstance {
   const parts = instance.split(".");
 
   if (parts.length < 2 || !parts[1]?.length) {
@@ -17,7 +21,7 @@ export function normalizeInstance(instance: string) {
   try {
     const urlObj = new URL(url);
     // toString() will include protocol, host, pathname, search, and hash
-    return `${urlObj.protocol}//${urlObj.host}`;
+    return `${urlObj.protocol}//${urlObj.host}` as NormalizedInstance;
   } catch {
     throw new Error(`Invalid URL: "${instance}"`);
   }

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -2095,17 +2095,15 @@ export function useInstancesQuery() {
           )
           .parse(json);
 
-        return _.shuffle(
-          _.uniqBy(
-            lemmy.map((item) => ({
-              host: new URL(item.url).host,
-              url: normalizeInstance(item.url),
-              software: item.software as typeof item.software | undefined,
-              description: item.description,
-              icon: item.icon,
-            })),
-            ({ url }) => url,
-          ),
+        return _.uniqBy(
+          lemmy.map((item) => ({
+            host: new URL(item.url).host.replace(/^www\./, ""),
+            url: normalizeInstance(item.url),
+            software: item.software as typeof item.software | undefined,
+            description: item.description,
+            icon: item.icon,
+          })),
+          ({ url }) => url,
         );
       } catch {
         return undefined;

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -765,17 +765,12 @@ export function useRegisterMutation(config: {
       if (res.jwt && config.instance) {
         const payload = {
           jwt: res.jwt,
+          instance: config.instance,
         };
         if (config?.addAccount) {
-          addAccount({
-            ...payload,
-            instance: config.instance,
-          });
+          addAccount(payload);
         } else {
-          updateSelectedAccount({
-            ...payload,
-            instance: config.instance,
-          });
+          updateSelectedAccount(payload);
         }
       }
       return res;
@@ -831,17 +826,12 @@ export function useLoginMutation(config: {
       if (res.jwt && config.instance) {
         const payload = {
           jwt: res.jwt,
+          instance: config.instance,
         };
         if (config?.addAccount) {
-          addAccount({
-            ...payload,
-            instance: config.instance,
-          });
+          addAccount(payload);
         } else {
-          updateSelectedAccount({
-            ...payload,
-            instance: config?.instance,
-          });
+          updateSelectedAccount(payload);
         }
       }
       return res;

--- a/src/stores/__snapshots__/comments.test.ts.snap
+++ b/src/stores/__snapshots__/comments.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`persisted state snapshot > comments store shape 1`] = `
 {
-  "test_123_0.456": {
+  "test_https://lemmy.world_0.456": {
     "data": {
       "answer": false,
       "apId": "https://blorpblorp.xyz/comment/456",
@@ -37,7 +37,7 @@ exports[`persisted state snapshot > comments store shape 1`] = `
 exports[`persisted state snapshot > comments store shape 2`] = `
 {
   "comments": {
-    "test_123_0.456": {
+    "test_https://lemmy.world_0.456": {
       "data": {
         "answer": false,
         "apId": "https://blorpblorp.xyz/comment/456",

--- a/src/stores/__snapshots__/communities.test.ts.snap
+++ b/src/stores/__snapshots__/communities.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`persisted state snapshot > communities store shape 1`] = `
 {
-  "test_123_1@blorpblorp.xyz": {
+  "test_https://lemmy.world_1@blorpblorp.xyz": {
     "data": {
       "communityView": {
         "apId": "https://blorpblorp.xyz/c/1",
@@ -37,7 +37,7 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor i
 exports[`persisted state snapshot > communities store shape 2`] = `
 {
   "communities": {
-    "test_123_1@blorpblorp.xyz": {
+    "test_https://lemmy.world_1@blorpblorp.xyz": {
       "data": {
         "communityView": {
           "apId": "https://blorpblorp.xyz/c/1",

--- a/src/stores/__snapshots__/flairs.test.ts.snap
+++ b/src/stores/__snapshots__/flairs.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`persisted state snapshot > flairs store shape 1`] = `
 {
-  "test_123_100": {
+  "test_https://lemmy.world_100": {
     "data": {
       "apId": "https://blorpblorp.xyz/flair/100",
       "backgroundColor": null,
@@ -18,7 +18,7 @@ exports[`persisted state snapshot > flairs store shape 1`] = `
 exports[`persisted state snapshot > flairs store shape 2`] = `
 {
   "flairs": {
-    "test_123_100": {
+    "test_https://lemmy.world_100": {
       "data": {
         "apId": "https://blorpblorp.xyz/flair/100",
         "backgroundColor": null,

--- a/src/stores/__snapshots__/multi-community-feeds.test.ts.snap
+++ b/src/stores/__snapshots__/multi-community-feeds.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`persisted state snapshot > feeds store shape 1`] = `
 {
-  "test_123_https://blorpblorp.xyz/feed/1": {
+  "test_https://lemmy.world_https://blorpblorp.xyz/feed/1": {
     "data": {
       "feedView": {
         "apId": "https://blorpblorp.xyz/feed/1",
@@ -29,7 +29,7 @@ exports[`persisted state snapshot > feeds store shape 1`] = `
 exports[`persisted state snapshot > feeds store shape 2`] = `
 {
   "feeds": {
-    "test_123_https://blorpblorp.xyz/feed/1": {
+    "test_https://lemmy.world_https://blorpblorp.xyz/feed/1": {
       "data": {
         "feedView": {
           "apId": "https://blorpblorp.xyz/feed/1",

--- a/src/stores/__snapshots__/posts.test.ts.snap
+++ b/src/stores/__snapshots__/posts.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`persisted state snapshot > posts store shape 1`] = `
 {
-  "test_123_https://blorpblorp.xyz/post/123": {
+  "test_https://lemmy.world_https://blorpblorp.xyz/post/123": {
     "data": {
       "altText": null,
       "apId": "https://blorpblorp.xyz/post/123",
@@ -50,7 +50,7 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor i
 exports[`persisted state snapshot > posts store shape 2`] = `
 {
   "posts": {
-    "test_123_https://blorpblorp.xyz/post/123": {
+    "test_https://lemmy.world_https://blorpblorp.xyz/post/123": {
       "data": {
         "altText": null,
         "apId": "https://blorpblorp.xyz/post/123",

--- a/src/stores/__snapshots__/profiles.test.ts.snap
+++ b/src/stores/__snapshots__/profiles.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`persisted state snapshot > profiles store shape 1`] = `
 {
-  "test_123_https://blorpblorp.xyz/u/789": {
+  "test_https://lemmy.world_https://blorpblorp.xyz/u/789": {
     "data": {
       "apId": "https://blorpblorp.xyz/u/789",
       "avatar": null,
@@ -25,7 +25,7 @@ exports[`persisted state snapshot > profiles store shape 1`] = `
 exports[`persisted state snapshot > profiles store shape 2`] = `
 {
   "profiles": {
-    "test_123_https://blorpblorp.xyz/u/789": {
+    "test_https://lemmy.world_https://blorpblorp.xyz/u/789": {
       "data": {
         "apId": "https://blorpblorp.xyz/u/789",
         "avatar": null,

--- a/src/stores/auth.test.ts
+++ b/src/stores/auth.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect, afterEach, vi } from "vitest";
+import { normalizeInstance } from "../normalize-instance";
 
 vi.mock("uuid", async (importOriginal) => {
   const actual = await importOriginal<typeof import("uuid")>();
@@ -7,17 +8,27 @@ vi.mock("uuid", async (importOriginal) => {
 import {
   useAuth,
   type Account,
-  AuthStoreData,
+  type AuthStoreData,
   getSelectedAccount,
   type KnownAccount,
   getAccountSite,
   useLoginSuggestions,
+  type UpdateAccount,
 } from "./auth";
 import { getSite, getPerson } from "@/test-utils/api";
 import { renderHook, act } from "@testing-library/react";
 import { faker } from "@faker-js/faker";
 import { env } from "../env";
 import z from "zod";
+
+function makeAccount(overrides?: Partial<UpdateAccount>): Account {
+  return {
+    jwt: faker.string.uuid(),
+    uuid: faker.string.uuid(),
+    ...overrides,
+    instance: normalizeInstance(overrides?.instance ?? faker.internet.url()),
+  };
+}
 
 afterEach(() => {
   const { result } = renderHook(() => useAuth());
@@ -29,23 +40,11 @@ afterEach(() => {
 describe("useAuthStore", () => {
   const { result } = renderHook(() => useAuth());
 
-  const account1 = {
-    instance: faker.internet.url().replace(/\/$/, ""),
-    jwt: faker.string.uuid(),
-    uuid: faker.string.uuid(),
-  };
+  const account1 = makeAccount();
 
-  const account2 = {
-    instance: faker.internet.url().replace(/\/$/, ""),
-    jwt: faker.string.uuid(),
-    uuid: faker.string.uuid(),
-  };
+  const account2 = makeAccount();
 
-  const account3 = {
-    instance: faker.internet.url().replace(/\/$/, ""),
-    jwt: faker.string.uuid(),
-    uuid: faker.string.uuid(),
-  };
+  const account3 = makeAccount();
 
   test("default instance", () => {
     expect(result.current.getSelectedAccount().instance).toBe(
@@ -156,7 +155,9 @@ describe("useAuthStore", () => {
       result.current.logout();
     });
     expect(result.current.accounts).toHaveLength(1);
-    expect(result.current.getSelectedAccount()).toMatchObject({
+    expect(result.current.getSelectedAccount()).toMatchObject<
+      Partial<KnownAccount>
+    >({
       instance: env.defaultInstance,
     });
   });
@@ -167,8 +168,10 @@ describe("useAuthStore", () => {
         instance: "https://fakelemmyinstance.com/",
       });
     });
-    expect(result.current.getSelectedAccount()).toMatchObject({
-      instance: "https://fakelemmyinstance.com",
+    expect(result.current.getSelectedAccount()).toMatchObject<
+      Partial<KnownAccount>
+    >({
+      instance: normalizeInstance("https://fakelemmyinstance.com"),
     });
   });
 });
@@ -199,15 +202,6 @@ describe("persisted state snapshot", () => {
 
 describe("useAuthStore merge", () => {
   const merge = useAuth.persist.getOptions().merge!;
-
-  function makeAccount(overrides?: Partial<Account>): Account {
-    return {
-      instance: faker.internet.url().replace(/\/$/, ""),
-      jwt: faker.string.uuid(),
-      uuid: faker.string.uuid(),
-      ...overrides,
-    };
-  }
 
   function makeCurrent(accounts: Account[]) {
     return {
@@ -708,7 +702,7 @@ describe("useAuthStore merge", () => {
       const guest = makeGuest();
       const guestWithUpdatedInstance = {
         ...guest,
-        instance: faker.internet.url().replace(/\/$/, ""),
+        instance: normalizeInstance(faker.internet.url()),
       };
       const persisted = {
         accounts: [guest],
@@ -842,21 +836,9 @@ describe("logoutMultiple", () => {
   test("removes multiple accounts and keeps the rest", () => {
     const { result } = renderHook(() => useAuth());
 
-    const account1 = {
-      instance: faker.internet.url().replace(/\/$/, ""),
-      jwt: faker.string.uuid(),
-      uuid: faker.string.uuid(),
-    };
-    const account2 = {
-      instance: faker.internet.url().replace(/\/$/, ""),
-      jwt: faker.string.uuid(),
-      uuid: faker.string.uuid(),
-    };
-    const account3 = {
-      instance: faker.internet.url().replace(/\/$/, ""),
-      jwt: faker.string.uuid(),
-      uuid: faker.string.uuid(),
-    };
+    const account1 = makeAccount();
+    const account2 = makeAccount();
+    const account3 = makeAccount();
 
     act(() => {
       result.current.updateSelectedAccount(account1);
@@ -876,16 +858,8 @@ describe("logoutMultiple", () => {
   test("falls back to guest when all accounts are logged out", () => {
     const { result } = renderHook(() => useAuth());
 
-    const account1 = {
-      instance: faker.internet.url().replace(/\/$/, ""),
-      jwt: faker.string.uuid(),
-      uuid: faker.string.uuid(),
-    };
-    const account2 = {
-      instance: faker.internet.url().replace(/\/$/, ""),
-      jwt: faker.string.uuid(),
-      uuid: faker.string.uuid(),
-    };
+    const account1 = makeAccount();
+    const account2 = makeAccount();
 
     act(() => {
       result.current.updateSelectedAccount(account1);
@@ -897,7 +871,9 @@ describe("logoutMultiple", () => {
     });
 
     expect(result.current.accounts).toHaveLength(1);
-    expect(result.current.getSelectedAccount()).toMatchObject({
+    expect(result.current.getSelectedAccount()).toMatchObject<
+      Partial<KnownAccount>
+    >({
       instance: env.defaultInstance,
     });
     expect(result.current.isLoggedIn()).toBe(false);
@@ -906,21 +882,9 @@ describe("logoutMultiple", () => {
   test("tracks loggedOutUuids", () => {
     const { result } = renderHook(() => useAuth());
 
-    const account1 = {
-      instance: faker.internet.url().replace(/\/$/, ""),
-      jwt: faker.string.uuid(),
-      uuid: faker.string.uuid(),
-    };
-    const account2 = {
-      instance: faker.internet.url().replace(/\/$/, ""),
-      jwt: faker.string.uuid(),
-      uuid: faker.string.uuid(),
-    };
-    const account3 = {
-      instance: faker.internet.url().replace(/\/$/, ""),
-      jwt: faker.string.uuid(),
-      uuid: faker.string.uuid(),
-    };
+    const account1 = makeAccount();
+    const account2 = makeAccount();
+    const account3 = makeAccount();
 
     act(() => {
       result.current.updateSelectedAccount(account1);
@@ -939,16 +903,8 @@ describe("logoutMultiple", () => {
   test("selected account falls back when current selection is logged out", () => {
     const { result } = renderHook(() => useAuth());
 
-    const account1 = {
-      instance: faker.internet.url().replace(/\/$/, ""),
-      jwt: faker.string.uuid(),
-      uuid: faker.string.uuid(),
-    };
-    const account2 = {
-      instance: faker.internet.url().replace(/\/$/, ""),
-      jwt: faker.string.uuid(),
-      uuid: faker.string.uuid(),
-    };
+    const account1 = makeAccount();
+    const account2 = makeAccount();
 
     act(() => {
       result.current.updateSelectedAccount(account1);
@@ -976,11 +932,7 @@ describe("updateAccountSite", () => {
   test("sets site and siteUpdatedAt on the matching account", () => {
     const { result } = renderHook(() => useAuth());
 
-    const account = {
-      instance: faker.internet.url().replace(/\/$/, ""),
-      jwt: faker.string.uuid(),
-      uuid: faker.string.uuid(),
-    };
+    const account = makeAccount();
 
     act(() => {
       result.current.updateSelectedAccount(account);
@@ -1024,7 +976,7 @@ describe("updateAccountSite", () => {
 
       expect(result.current.knownAccounts).toHaveLength(1);
       expect(result.current.knownAccounts![0]).toMatchObject<KnownAccount>({
-        instance: "lemmy.world",
+        instance: normalizeInstance("https://lemmy.world"),
         username: "123user@lemmy.world",
       });
     });
@@ -1098,11 +1050,9 @@ describe("useLoginSuggestions", () => {
     const auth = renderHook(() => useAuth());
     const suggestions = renderHook(() => useLoginSuggestions(INSTANCE));
 
-    const account = {
+    const account = makeAccount({
       instance: INSTANCE,
-      jwt: faker.string.uuid(),
-      uuid: faker.string.uuid(),
-    };
+    });
     const person = getPerson({ apId: `${INSTANCE}/u/alice` });
     const siteWithMe = getSite({ instance: INSTANCE, me: person });
 
@@ -1118,8 +1068,8 @@ describe("useLoginSuggestions", () => {
 
     suggestions.rerender();
     expect(suggestions.result.current).toHaveLength(1);
-    expect(suggestions.result.current[0]).toMatchObject({
-      instance: "lemmy.world",
+    expect(suggestions.result.current[0]).toMatchObject<Partial<KnownAccount>>({
+      instance: normalizeInstance("https://lemmy.world"),
     });
   });
 
@@ -1150,16 +1100,12 @@ describe("useLoginSuggestions", () => {
   test("returns multiple suggestions when several accounts are logged out", () => {
     const { auth, suggestions } = setup();
 
-    const account1 = {
+    const account1 = makeAccount({
       instance: INSTANCE,
-      jwt: faker.string.uuid(),
-      uuid: faker.string.uuid(),
-    };
-    const account2 = {
+    });
+    const account2 = makeAccount({
       instance: INSTANCE,
-      jwt: faker.string.uuid(),
-      uuid: faker.string.uuid(),
-    };
+    });
     const person1 = getPerson({ id: 1 });
     const person2 = getPerson({ id: 2 });
 
@@ -1190,16 +1136,12 @@ describe("useLoginSuggestions", () => {
   test("only suggests logged-out accounts when some are still logged in", () => {
     const { auth, suggestions } = setup();
 
-    const account1 = {
+    const account1 = makeAccount({
       instance: INSTANCE,
-      jwt: faker.string.uuid(),
-      uuid: faker.string.uuid(),
-    };
-    const account2 = {
+    });
+    const account2 = makeAccount({
       instance: INSTANCE,
-      jwt: faker.string.uuid(),
-      uuid: faker.string.uuid(),
-    };
+    });
     const person1 = getPerson({ id: 1 });
     const person2 = getPerson({ id: 2 });
 

--- a/src/stores/auth.test.ts
+++ b/src/stores/auth.test.ts
@@ -9,8 +9,11 @@ import {
   type Account,
   AuthStoreData,
   getSelectedAccount,
+  type KnownAccount,
+  getAccountSite,
+  useLoginSuggestions,
 } from "./auth";
-import { getSite } from "@/test-utils/api";
+import { getSite, getPerson } from "@/test-utils/api";
 import { renderHook, act } from "@testing-library/react";
 import { faker } from "@faker-js/faker";
 import { env } from "../env";
@@ -231,11 +234,13 @@ describe("useAuthStore merge", () => {
         ...account,
         site: getSite({ description: "fresh-current" }),
         siteUpdatedAt: 100,
-      } as Account,
+      } satisfies Account,
     ]);
     const result = merge(persisted, current);
     expect(result.accounts[0]!.siteUpdatedAt).toBe(100);
-    expect((result.accounts[0] as any).site?.description).toBe("fresh-current");
+    expect(getAccountSite(result.accounts[0]!)?.description).toBe(
+      "fresh-current",
+    );
   });
 
   test("persisted account wins when siteUpdatedAt is newer (multi-tab sync)", () => {
@@ -255,11 +260,11 @@ describe("useAuthStore merge", () => {
         ...account,
         site: getSite({ description: "stale-current" }),
         siteUpdatedAt: 50,
-      } as Account,
+      } satisfies Account,
     ]);
     const result = merge(persisted, current);
     expect(result.accounts[0]!.siteUpdatedAt).toBe(100);
-    expect((result.accounts[0] as any).site?.description).toBe(
+    expect(getAccountSite(result.accounts[0]!)?.description).toBe(
       "fresh-persisted",
     );
   });
@@ -302,7 +307,7 @@ describe("useAuthStore merge", () => {
       ...account1,
       site: getSite({ description: "a1-stale-current" }),
       siteUpdatedAt: 50,
-    } as Account;
+    } satisfies Account;
     // account2: current tab updated the site more recently
     const account2 = makeAccount();
     const account2Persisted = {
@@ -314,7 +319,7 @@ describe("useAuthStore merge", () => {
       ...account2,
       site: getSite({ description: "a2-fresh-current" }),
       siteUpdatedAt: 100,
-    } as Account;
+    } satisfies Account;
 
     const persisted = {
       accounts: [account1Persisted, account2Persisted],
@@ -329,10 +334,10 @@ describe("useAuthStore merge", () => {
     const r2 = result.accounts.find((a) => a.uuid === account2.uuid)!;
 
     expect(r1.siteUpdatedAt).toBe(100);
-    expect((r1 as any).site?.description).toBe("a1-fresh-persisted");
+    expect(getAccountSite(r1!)?.description).toBe("a1-fresh-persisted");
 
     expect(r2.siteUpdatedAt).toBe(100);
-    expect((r2 as any).site?.description).toBe("a2-fresh-current");
+    expect(getAccountSite(r2!)?.description).toBe("a2-fresh-current");
   });
 
   test("account logged out in another tab is not re-added by current tab", () => {
@@ -994,5 +999,231 @@ describe("updateAccountSite", () => {
     expect("site" in updated && updated.site?.description).toBe("test-site");
     expect(updated.siteUpdatedAt).toBeGreaterThanOrEqual(before);
     expect(updated.siteUpdatedAt).toBeLessThanOrEqual(after);
+  });
+
+  describe("knownAccounts", () => {
+    function makeAccount(instance: string) {
+      return {
+        instance,
+        jwt: faker.string.uuid(),
+        uuid: faker.string.uuid(),
+      };
+    }
+
+    test("adds entry when site.me is present", () => {
+      const { result } = renderHook(() => useAuth());
+      const account = makeAccount("https://lemmy.world");
+
+      act(() => result.current.updateSelectedAccount(account));
+      act(() =>
+        result.current.updateAccountSite(
+          account.uuid,
+          getSite({ me: getPerson({ slug: "123user@lemmy.world" }) }),
+        ),
+      );
+
+      expect(result.current.knownAccounts).toHaveLength(1);
+      expect(result.current.knownAccounts![0]).toMatchObject<KnownAccount>({
+        instance: "lemmy.world",
+        username: "123user@lemmy.world",
+      });
+    });
+
+    test("does not add entry when site.me is null", () => {
+      const { result } = renderHook(() => useAuth());
+      const account = makeAccount("https://lemmy.world");
+
+      act(() => result.current.updateSelectedAccount(account));
+      act(() =>
+        result.current.updateAccountSite(account.uuid, getSite({ me: null })),
+      );
+
+      expect(result.current.knownAccounts ?? []).toHaveLength(0);
+    });
+
+    test("does not create duplicates when the same account is updated twice", () => {
+      const { result } = renderHook(() => useAuth());
+      const account = makeAccount("https://lemmy.world");
+      const person = getPerson();
+
+      act(() => result.current.updateSelectedAccount(account));
+      act(() =>
+        result.current.updateAccountSite(account.uuid, getSite({ me: person })),
+      );
+      act(() =>
+        result.current.updateAccountSite(account.uuid, getSite({ me: person })),
+      );
+
+      expect(result.current.knownAccounts).toHaveLength(1);
+    });
+
+    test("tracks two different users on the same instance separately", () => {
+      const { result } = renderHook(() => useAuth());
+      const account1 = makeAccount("https://lemmy.world");
+      const account2 = { ...makeAccount("https://lemmy.world") };
+      const person1 = getPerson({ id: 1, apId: "https://lemmy.world/u/alice" });
+      const person2 = getPerson({ id: 2, apId: "https://lemmy.world/u/bob" });
+
+      act(() => {
+        result.current.updateSelectedAccount(account1);
+        result.current.addAccount(account2);
+      });
+      act(() =>
+        result.current.updateAccountSite(
+          account1.uuid,
+          getSite({ me: person1 }),
+        ),
+      );
+      act(() =>
+        result.current.updateAccountSite(
+          account2.uuid,
+          getSite({ me: person2 }),
+        ),
+      );
+
+      expect(result.current.knownAccounts).toHaveLength(2);
+    });
+  });
+});
+
+describe("useLoginSuggestions", () => {
+  afterEach(() => {
+    const { result } = renderHook(() => useAuth());
+    act(() => result.current.reset());
+  });
+
+  const INSTANCE = "https://lemmy.world";
+
+  function setup() {
+    const auth = renderHook(() => useAuth());
+    const suggestions = renderHook(() => useLoginSuggestions(INSTANCE));
+
+    const account = {
+      instance: INSTANCE,
+      jwt: faker.string.uuid(),
+      uuid: faker.string.uuid(),
+    };
+    const person = getPerson({ apId: `${INSTANCE}/u/alice` });
+    const siteWithMe = getSite({ instance: INSTANCE, me: person });
+
+    return { auth, suggestions, account, person, siteWithMe };
+  }
+
+  test("returns suggestion after logging out", () => {
+    const { auth, suggestions, account, siteWithMe } = setup();
+
+    act(() => auth.result.current.updateSelectedAccount(account));
+    act(() => auth.result.current.updateAccountSite(account.uuid, siteWithMe));
+    act(() => auth.result.current.logout(account.uuid));
+
+    suggestions.rerender();
+    expect(suggestions.result.current).toHaveLength(1);
+    expect(suggestions.result.current[0]).toMatchObject({
+      instance: "lemmy.world",
+    });
+  });
+
+  test("returns empty when currently logged in", () => {
+    const { auth, suggestions, account, siteWithMe } = setup();
+
+    act(() => auth.result.current.updateSelectedAccount(account));
+    act(() => auth.result.current.updateAccountSite(account.uuid, siteWithMe));
+
+    suggestions.rerender();
+    expect(suggestions.result.current).toHaveLength(0);
+  });
+
+  test("returns empty for an unknown instance", () => {
+    const { auth, account, siteWithMe } = setup();
+    const suggestions = renderHook(() =>
+      useLoginSuggestions("https://piefed.social"),
+    );
+
+    act(() => auth.result.current.updateSelectedAccount(account));
+    act(() => auth.result.current.updateAccountSite(account.uuid, siteWithMe));
+    act(() => auth.result.current.logout(account.uuid));
+
+    suggestions.rerender();
+    expect(suggestions.result.current).toHaveLength(0);
+  });
+
+  test("returns multiple suggestions when several accounts are logged out", () => {
+    const { auth, suggestions } = setup();
+
+    const account1 = {
+      instance: INSTANCE,
+      jwt: faker.string.uuid(),
+      uuid: faker.string.uuid(),
+    };
+    const account2 = {
+      instance: INSTANCE,
+      jwt: faker.string.uuid(),
+      uuid: faker.string.uuid(),
+    };
+    const person1 = getPerson({ id: 1 });
+    const person2 = getPerson({ id: 2 });
+
+    act(() => {
+      auth.result.current.updateSelectedAccount(account1);
+      auth.result.current.addAccount(account2);
+    });
+    act(() =>
+      auth.result.current.updateAccountSite(
+        account1.uuid,
+        getSite({ instance: INSTANCE, me: person1 }),
+      ),
+    );
+    act(() =>
+      auth.result.current.updateAccountSite(
+        account2.uuid,
+        getSite({ instance: INSTANCE, me: person2 }),
+      ),
+    );
+    act(() =>
+      auth.result.current.logoutMultiple([account1.uuid, account2.uuid]),
+    );
+
+    suggestions.rerender();
+    expect(suggestions.result.current).toHaveLength(2);
+  });
+
+  test("only suggests logged-out accounts when some are still logged in", () => {
+    const { auth, suggestions } = setup();
+
+    const account1 = {
+      instance: INSTANCE,
+      jwt: faker.string.uuid(),
+      uuid: faker.string.uuid(),
+    };
+    const account2 = {
+      instance: INSTANCE,
+      jwt: faker.string.uuid(),
+      uuid: faker.string.uuid(),
+    };
+    const person1 = getPerson({ id: 1 });
+    const person2 = getPerson({ id: 2 });
+
+    act(() => {
+      auth.result.current.updateSelectedAccount(account1);
+      auth.result.current.addAccount(account2);
+    });
+    act(() =>
+      auth.result.current.updateAccountSite(
+        account1.uuid,
+        getSite({ instance: INSTANCE, me: person1 }),
+      ),
+    );
+    act(() =>
+      auth.result.current.updateAccountSite(
+        account2.uuid,
+        getSite({ instance: INSTANCE, me: person2 }),
+      ),
+    );
+    // Only log out account1, keep account2 logged in
+    act(() => auth.result.current.logout(account1.uuid));
+
+    suggestions.rerender();
+    expect(suggestions.result.current).toHaveLength(1);
+    expect(suggestions.result.current[0]!.username).toBe(person1.slug);
   });
 });

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -9,6 +9,7 @@ import { Schemas, siteSchema } from "../apis/api-blueprint";
 import { v4 as uuid } from "uuid";
 import { isTest } from "../lib/device";
 import { normalizeInstance } from "../normalize-instance";
+import { DistributedOmit } from "type-fest";
 
 export type CacheKey = `cache_${string}`;
 export type CachePrefixer = (cacheKey: string | number) => CacheKey;
@@ -37,14 +38,14 @@ export function getCachePrefixer(account: Account | undefined): CachePrefixer {
 
 const accountSchema = z.union([
   z.object({
-    instance: z.string(),
+    instance: z.string().transform(normalizeInstance),
     jwt: z.string().optional(),
     site: siteSchema,
     uuid: z.string(),
     siteUpdatedAt: z.number().optional(),
   }),
   z.object({
-    instance: z.string(),
+    instance: z.string().transform(normalizeInstance),
     jwt: z.string().optional(),
     uuid: z.string(),
     siteUpdatedAt: z.number().optional(),
@@ -53,8 +54,12 @@ const accountSchema = z.union([
 
 export type Account = z.infer<typeof accountSchema>;
 
+export type UpdateAccount = DistributedOmit<Account, "instance"> & {
+  instance: string;
+};
+
 const knownAccountSchema = z.object({
-  instance: z.string(),
+  instance: z.string().transform(normalizeInstance),
   username: z.string(),
 });
 
@@ -76,9 +81,9 @@ type Uuid = string;
 type AuthStore = {
   getSelectedAccount: () => Account;
   isLoggedIn: () => boolean;
-  updateSelectedAccount: (patch: Partial<Account>) => any;
+  updateSelectedAccount: (patch: Partial<UpdateAccount>) => any;
   updateAccountSite: (uuid: Uuid, site: Schemas.Site) => any;
-  addAccount: (patch?: Partial<Account>) => any;
+  addAccount: (patch?: Partial<UpdateAccount>) => any;
   selectAccount: (uuid: Uuid) => Account | null;
   logout: (uuid?: Uuid) => any;
   logoutMultiple: (uuids: Uuid[]) => any;
@@ -263,13 +268,10 @@ export const useAuth = create<AuthStore>()(
         );
         if (site.me) {
           const account = accounts.find((a) => a.uuid === selectedUuid);
-          const instance = account
-            ? new URL(normalizeInstance(account.instance)).host
-            : null;
           const username = site.me.slug;
-          if (instance && username) {
+          if (account?.instance && username) {
             knownAccounts = _.uniqBy(
-              [{ instance, username }, ...knownAccounts],
+              [{ instance: account.instance, username }, ...knownAccounts],
               (ka) => `${ka.instance}:${ka.username}`,
             ).slice(0, MAX_KNOWN_ACCOUNTS);
           }
@@ -285,6 +287,7 @@ export const useAuth = create<AuthStore>()(
             ? {
                 ...a,
                 ...patch,
+                instance: normalizeInstance(patch.instance ?? a.instance),
                 ...("site" in patch && patch.site
                   ? { siteUpdatedAt: Date.now() }
                   : null),
@@ -473,12 +476,7 @@ export function useLoginSuggestions(instance: string) {
 
       const { knownAccounts = [], accounts } = state;
 
-      let host: string;
-      try {
-        host = new URL(normalizeInstance(instance)).host;
-      } catch {
-        return [];
-      }
+      const normalizedInstance = normalizeInstance(instance);
 
       const loggedInSlugs = new Set(
         _.compact(
@@ -487,18 +485,15 @@ export function useLoginSuggestions(instance: string) {
               if (!a.jwt) {
                 return false;
               }
-              try {
-                return new URL(normalizeInstance(a.instance)).host === host;
-              } catch {
-                return false;
-              }
+              return a.instance === normalizedInstance;
             })
             .map((a) => getAccountSite(a)?.me?.slug),
         ),
       );
 
       return knownAccounts.filter(
-        (ka) => ka.instance === host && !loggedInSlugs.has(ka.username),
+        (ka) =>
+          ka.instance === normalizedInstance && !loggedInSlugs.has(ka.username),
       );
     }),
   );

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
+import { useShallow } from "zustand/shallow";
 import { createStorage, sync } from "./storage";
 import _ from "lodash";
 import { env } from "../env";
@@ -13,6 +14,7 @@ export type CacheKey = `cache_${string}`;
 export type CachePrefixer = (cacheKey: string | number) => CacheKey;
 
 const MAX_LOGGED_OUT_UUIDS = 20;
+const MAX_KNOWN_ACCOUNTS = 20;
 
 export function getCachePrefixer(account: Account | undefined): CachePrefixer {
   let prefix = "";
@@ -51,10 +53,18 @@ const accountSchema = z.union([
 
 export type Account = z.infer<typeof accountSchema>;
 
+const knownAccountSchema = z.object({
+  instance: z.string(),
+  username: z.string(),
+});
+
+export type KnownAccount = z.infer<typeof knownAccountSchema>;
+
 const storeSchema = z.object({
   accounts: z.array(accountSchema),
   selectedUuid: z.string().optional(),
   loggedOutUuids: z.array(z.string()).optional(),
+  knownAccounts: z.array(knownAccountSchema).optional(),
   /** @deprecated Hard-coded to 0. Kept so v4 can still parse this store without throwing. */
   accountIndex: z.number().optional(),
 });
@@ -119,6 +129,7 @@ function getNewAccount(): Account {
 
 const INIT_STATE = {
   accounts: [getNewAccount()],
+  knownAccounts: [] satisfies KnownAccount[],
   /** @deprecated Hard-coded to 0. Kept so v4 can still parse this store without throwing. */
   accountIndex: 0,
 };
@@ -244,19 +255,26 @@ export const useAuth = create<AuthStore>()(
       },
       updateAccountSite: (selectedUuid, site) => {
         const state = get();
-        let { accounts } = state;
+        let { accounts, knownAccounts = [] } = state;
         accounts = accounts.map((a) =>
           a.uuid === selectedUuid
-            ? {
-                ...a,
-                site,
-                siteUpdatedAt: Date.now(),
-              }
+            ? { ...a, site, siteUpdatedAt: Date.now() }
             : a,
         );
-        set({
-          accounts,
-        });
+        if (site.me) {
+          const account = accounts.find((a) => a.uuid === selectedUuid);
+          const instance = account
+            ? new URL(normalizeInstance(account.instance)).host
+            : null;
+          const username = site.me.slug;
+          if (instance && username) {
+            knownAccounts = _.uniqBy(
+              [{ instance, username }, ...knownAccounts],
+              (ka) => `${ka.instance}:${ka.username}`,
+            ).slice(0, MAX_KNOWN_ACCOUNTS);
+          }
+        }
+        set({ accounts, knownAccounts });
       },
       updateSelectedAccount: (patch) => {
         const state = get();
@@ -444,4 +462,44 @@ export function useAmIAdmin() {
     const site = getAccountSite(account);
     return site?.me?.apId && site?.admins?.includes(site.me?.apId);
   });
+}
+
+export function useLoginSuggestions(instance: string) {
+  return useAuth(
+    useShallow((state) => {
+      if (instance.trim().length === 0) {
+        return [];
+      }
+
+      const { knownAccounts = [], accounts } = state;
+
+      let host: string;
+      try {
+        host = new URL(normalizeInstance(instance)).host;
+      } catch {
+        return [];
+      }
+
+      const loggedInSlugs = new Set(
+        _.compact(
+          accounts
+            .filter((a) => {
+              if (!a.jwt) {
+                return false;
+              }
+              try {
+                return new URL(normalizeInstance(a.instance)).host === host;
+              } catch {
+                return false;
+              }
+            })
+            .map((a) => getAccountSite(a)?.me?.slug),
+        ),
+      );
+
+      return knownAccounts.filter(
+        (ka) => ka.instance === host && !loggedInSlugs.has(ka.username),
+      );
+    }),
+  );
 }

--- a/src/stores/comments.test.ts
+++ b/src/stores/comments.test.ts
@@ -11,9 +11,13 @@ import {
 import * as api from "@/test-utils/api";
 import { useCommentsStore } from "./comments";
 import { getCachePrefixer } from "./auth";
+import { normalizeInstance } from "../normalize-instance";
 import _ from "lodash";
 
-const prefix = getCachePrefixer({ instance: "123", uuid: "test" });
+const prefix = getCachePrefixer({
+  instance: normalizeInstance("lemmy.world"),
+  uuid: "test",
+});
 
 afterEach(() => {
   useCommentsStore.getState().reset();

--- a/src/stores/communities.test.ts
+++ b/src/stores/communities.test.ts
@@ -13,8 +13,12 @@ import _ from "lodash";
 import { renderHook, act } from "@testing-library/react";
 import { SubscribedType } from "lemmy-v3";
 import { getCachePrefixer } from "./auth";
+import { normalizeInstance } from "../normalize-instance";
 
-const prefix = getCachePrefixer({ instance: "123", uuid: "test" });
+const prefix = getCachePrefixer({
+  instance: normalizeInstance("lemmy.world"),
+  uuid: "test",
+});
 
 afterEach(() => {
   const { result } = renderHook(() => useCommunitiesStore());

--- a/src/stores/flairs.test.ts
+++ b/src/stores/flairs.test.ts
@@ -3,9 +3,13 @@ import { describe, test, expect, beforeAll, afterAll, vi } from "vitest";
 import * as api from "@/test-utils/api";
 import { useFlairsStore } from "./flairs";
 import { getCachePrefixer } from "./auth";
+import { normalizeInstance } from "../normalize-instance";
 import _ from "lodash";
 
-const prefix = getCachePrefixer({ instance: "123", uuid: "test" });
+const prefix = getCachePrefixer({
+  instance: normalizeInstance("lemmy.world"),
+  uuid: "test",
+});
 
 describe("merge (cross-tab version skew protection)", () => {
   test("accepts valid persisted flairs", () => {

--- a/src/stores/multi-community-feeds.test.ts
+++ b/src/stores/multi-community-feeds.test.ts
@@ -11,10 +11,14 @@ import * as api from "@/test-utils/api";
 import { useMultiCommunityFeedStore } from "./multi-community-feeds";
 import { renderHook, act } from "@testing-library/react";
 import { getCachePrefixer } from "./auth";
+import { normalizeInstance } from "../normalize-instance";
 import { getFeedSubscribed } from "../apis/utils";
 import _ from "lodash";
 
-const prefix = getCachePrefixer({ instance: "123", uuid: "test" });
+const prefix = getCachePrefixer({
+  instance: normalizeInstance("lemmy.world"),
+  uuid: "test",
+});
 
 afterEach(() => {
   const { result } = renderHook(() => useMultiCommunityFeedStore());

--- a/src/stores/posts.test.ts
+++ b/src/stores/posts.test.ts
@@ -12,9 +12,13 @@ import * as api from "@/test-utils/api";
 import { usePostsStore } from "./posts";
 import _ from "lodash";
 import { getCachePrefixer } from "./auth";
+import { normalizeInstance } from "../normalize-instance";
 import { Schemas } from "../apis/api-blueprint";
 
-const prefix = getCachePrefixer({ instance: "123", uuid: "test" });
+const prefix = getCachePrefixer({
+  instance: normalizeInstance("lemmy.world"),
+  uuid: "test",
+});
 
 afterEach(() => {
   const { result } = renderHook(() => usePostsStore());

--- a/src/stores/profiles.test.ts
+++ b/src/stores/profiles.test.ts
@@ -11,9 +11,13 @@ import {
 import * as api from "@/test-utils/api";
 import { useProfilesStore } from "./profiles";
 import { getCachePrefixer } from "./auth";
+import { normalizeInstance } from "../normalize-instance";
 import _ from "lodash";
 
-const prefix = getCachePrefixer({ instance: "123", uuid: "test" });
+const prefix = getCachePrefixer({
+  instance: normalizeInstance("lemmy.world"),
+  uuid: "test",
+});
 
 afterEach(() => {
   useProfilesStore.getState().reset();

--- a/test-utils/api.ts
+++ b/test-utils/api.ts
@@ -46,7 +46,6 @@ export function getPerson(overrides?: Partial<Schemas.Person>): Schemas.Person {
   return {
     createdAt: relativeTime(),
     id,
-    apId,
     avatar: null,
     slug: createSlug({ apId, name: String(id) }).slug,
     matrixUserId: null,
@@ -56,6 +55,8 @@ export function getPerson(overrides?: Partial<Schemas.Person>): Schemas.Person {
     isBanned: false,
     postCount: 100,
     commentCount: 2000,
+    ...overrides,
+    apId,
   };
 }
 


### PR DESCRIPTION
- Improved the login form UX — modal now opens directly to the login step rather than instance selection
- Improved the signup form and fixed a captcha reset bug
- Added a human-readable error when a user tries to log into an unsupported instance (e.g. Mastodon), including the received software name in the message
- Added zodEnumMessage tagged template helper and getFirstZodIssue utility in src/lib/zod.ts for cleaner Zod error handling
- Added an "All" filter alongside Lemmy/PieFed filters in instance selection
- The back/change-instance button is now hidden when REACT_APP_LOCK_TO_DEFAULT_INSTANCE is set
  Fixed e2e tests to match the new login flow (modal opens at login step, not instance selection)
- Expanded e2e login test coverage: added tests for logging in with the default instance and for the locked-instance UI