### PR TITLE
Add alt text input to create-post screen

### DIFF
--- a/src/features/create-post/index.tsx
+++ b/src/features/create-post/index.tsx
@@ -663,18 +663,22 @@ function CreatePostInner() {
                       </p>
                     )}
                   </div>
-                  <Label htmlFor={`${id}-alt-text`}>Alt text</Label>
-                  <Input
-                    id={`${id}-alt-text`}
-                    data-testid="create-post-alt-text"
-                    placeholder="Describe the image for screen readers"
-                    value={draft.altText ?? ""}
-                    onChange={(e) =>
-                      patchDraft({
-                        altText: e.target.value || null,
-                      })
-                    }
-                  />
+                  {(draft.type === "media" || !!draft.thumbnailUrl) && (
+                    <>
+                      <Label htmlFor={`${id}-alt-text`}>Alt text</Label>
+                      <Input
+                        id={`${id}-alt-text`}
+                        data-testid="create-post-alt-text"
+                        placeholder="Describe the image for screen readers"
+                        value={draft.altText ?? ""}
+                        onChange={(e) =>
+                          patchDraft({
+                            altText: e.target.value || null,
+                          })
+                        }
+                      />
+                    </>
+                  )}
                 </div>
               )}
 

--- a/src/features/create-post/index.tsx
+++ b/src/features/create-post/index.tsx
@@ -663,6 +663,18 @@ function CreatePostInner() {
                       </p>
                     )}
                   </div>
+                  <Label htmlFor={`${id}-alt-text`}>Alt text</Label>
+                  <Input
+                    id={`${id}-alt-text`}
+                    data-testid="create-post-alt-text"
+                    placeholder="Describe the image for screen readers"
+                    value={draft.altText ?? ""}
+                    onChange={(e) =>
+                      patchDraft({
+                        altText: e.target.value || null,
+                      })
+                    }
+                  />
                 </div>
               )}
 

--- a/src/stores/create-post.test.ts
+++ b/src/stores/create-post.test.ts
@@ -131,6 +131,66 @@ describe("poll round trip", () => {
   });
 });
 
+describe("alt text", () => {
+  const ALT = "A cat on a windowsill";
+
+  test("postToDraft carries altText from the source post", () => {
+    const { post } = api.getPost({
+      variant: "image",
+      post: { altText: ALT },
+    });
+    const draft = postToDraft(post);
+    expect(draft.altText).toBe(ALT);
+  });
+
+  test("draftToCreatePostData outputs altText", () => {
+    const draft: Draft = {
+      type: "media",
+      createdAt: Date.now(),
+      title: "Image post",
+      communityHandle: "test@example.com",
+      thumbnailUrl: "https://example.com/img.jpg",
+      altText: ALT,
+    };
+    const created = draftToCreatePostData(draft);
+    expect(created.altText).toBe(ALT);
+  });
+
+  test("draftToEditPostData outputs altText", () => {
+    const draft: Draft = {
+      type: "media",
+      createdAt: Date.now(),
+      title: "Image post",
+      communityHandle: "test@example.com",
+      apId: "https://example.com/post/1",
+      thumbnailUrl: "https://example.com/img.jpg",
+      altText: ALT,
+    };
+    const edited = draftToEditPostData(draft);
+    expect(edited.altText).toBe(ALT);
+  });
+
+  test("postToDraft → draftToEditPostData preserves altText", () => {
+    const { post } = api.getPost({
+      variant: "image",
+      post: { altText: ALT },
+    });
+    const draft = postToDraft(post);
+    const edited = draftToEditPostData(draft);
+    expect(edited.altText).toBe(ALT);
+  });
+
+  test("postToDraft → draftToEditPostData preserves null altText", () => {
+    const { post } = api.getPost({
+      variant: "image",
+      post: { altText: null },
+    });
+    const draft = postToDraft(post);
+    const edited = draftToEditPostData(draft);
+    expect(edited.altText).toBeNull();
+  });
+});
+
 describe("persisted state snapshot", () => {
   beforeAll(() => {
     vi.useFakeTimers();


### PR DESCRIPTION
Renders below the image upload whenever the post type is 'media' or 'link'. Alt text was already plumbed through postToDraft / draftToCreatePostData / draftToEditPostData and the Lemmy + PieFed API mappers, so only the UI surface was missing.

Backs the existing draft <-> post round trip with explicit tests so the field can't be silently dropped in future refactors.