### PR TITLE
feat: ellipse sticky post title to 1 line, add vote subtitle

### DIFF
--- a/src/components/comments/comment-buttons.tsx
+++ b/src/components/comments/comment-buttons.tsx
@@ -156,8 +156,10 @@ export function CommentVoting({
   className?: string;
   fixRightAlignment?: boolean;
 }) {
-  const enableDownvotes = useServerEnablesDownvotes("enableCommentDownvotes");
-  const scoreDisplay = useScoreDisplayPreference();
+  const serverEnablesDownvotes = useServerEnablesDownvotes(
+    "enableCommentDownvotes",
+  );
+  const scoreDisplayPreference = useScoreDisplayPreference();
 
   const upvoteId = useId();
   const downvoteId = useId();
@@ -176,11 +178,14 @@ export function CommentVoting({
   const abbrvUpvotes = abbriviateNumberParts(displayUpvotes);
   const abbrvDownvotes = abbriviateNumberParts(-displayDownvotes);
 
+  const prefersDownvotes = scoreDisplayPreference === "downvotes";
+  const prefersUpvotes = scoreDisplayPreference === "upvotes";
+  const prefersScore = scoreDisplayPreference === "score";
+
   // Heart mode — server has disabled downvotes.
   // Only show a count for score/upvotes display modes; downvotes-only makes no
   // sense when the server doesn't support them.
-  if (!enableDownvotes) {
-    const showCount = scoreDisplay === "score" || scoreDisplay === "upvotes";
+  if (!serverEnablesDownvotes || scoreDisplayPreference === "none") {
     return (
       <Button
         size="sm"
@@ -200,39 +205,32 @@ export function CommentVoting({
         )}
       >
         {isUpvoted ? <FaHeart /> : <FaRegHeart />}
-        {showCount &&
-          abbriviateNumber(
-            scoreDisplay === "upvotes" ? displayUpvotes : displayScore,
-          )}
+        {prefersScore && abbriviateNumber(displayScore)}
+        {prefersUpvotes && abbriviateNumber(displayUpvotes)}
       </Button>
     );
   }
 
-  const isDownvoteSide = scoreDisplay === "downvotes";
-  const countAbbrv = isDownvoteSide
+  const countAbbrv = prefersDownvotes
     ? abbrvDownvotes
-    : scoreDisplay === "upvotes"
+    : prefersUpvotes
       ? abbrvUpvotes
       : abbrvScore;
-  const tooltipText = isDownvoteSide
+  const tooltipText = prefersDownvotes
     ? `${displayDownvotes} downvotes`
-    : scoreDisplay === "upvotes"
+    : prefersUpvotes
       ? `${displayUpvotes} upvotes`
       : `${displayUpvotes} upvotes, ${displayDownvotes} downvotes`;
 
-  const countNode = scoreDisplay !== "none" && (
+  const countNode = (
     <Tooltip>
       <TooltipTrigger aria-label={tooltipText}>
-        <label htmlFor={isDownvoteSide ? downvoteId : upvoteId}>
+        <label htmlFor={prefersDownvotes ? downvoteId : upvoteId}>
           <NumberFlow
             className={cn(
               "-mx-0.5 cursor-pointer",
-              isDownvoteSide
-                ? isDownvoted && "text-brand-secondary"
-                : cn(
-                    isUpvoted && "text-brand",
-                    isDownvoted && "text-brand-secondary",
-                  ),
+              isUpvoted && !prefersDownvotes && "text-brand",
+              isDownvoted && !prefersUpvotes && "text-brand-secondary",
             )}
             suffix={countAbbrv.suffix}
             value={countAbbrv.number}
@@ -277,13 +275,15 @@ export function CommentVoting({
       </Button>
 
       {/* Separator left of count — only in downvotes mode */}
-      {isDownvoteSide && <Separator orientation="vertical" className="h-4" />}
+      {prefersDownvotes && (
+        <Separator orientation="vertical" className="min-h-4 mr-2.5" />
+      )}
 
       {countNode}
 
       {/* Separator right of count — only in upvotes mode */}
-      {scoreDisplay === "upvotes" && (
-        <Separator orientation="vertical" className="h-4" />
+      {prefersUpvotes && (
+        <Separator orientation="vertical" className="min-h-4 ml-2.5" />
       )}
 
       <Button

--- a/src/components/comments/comment-buttons.tsx
+++ b/src/components/comments/comment-buttons.tsx
@@ -18,7 +18,10 @@ import { Tooltip, TooltipTrigger, TooltipContent } from "../ui/tooltip";
 import { useDoubleTap } from "use-double-tap";
 import { useMedia, useRequireAuth } from "@/src/hooks";
 import { useSettingsStore } from "@/src/stores/settings";
-import { useShouldShowDownvotes, useScoreDisplay } from "@/src/stores/utils";
+import {
+  useServerEnablesDownvotes,
+  useScoreDisplayPreference,
+} from "@/src/stores/utils";
 import { Separator } from "../ui/separator";
 import { NumberFlow } from "../number-flow";
 import { MAX_REACTIONS } from "../posts/config";
@@ -153,8 +156,8 @@ export function CommentVoting({
   className?: string;
   fixRightAlignment?: boolean;
 }) {
-  const enableDownvotes = useShouldShowDownvotes("enableCommentDownvotes");
-  const scoreDisplay = useScoreDisplay();
+  const enableDownvotes = useServerEnablesDownvotes("enableCommentDownvotes");
+  const scoreDisplay = useScoreDisplayPreference();
 
   const upvoteId = useId();
   const downvoteId = useId();

--- a/src/components/posts/post-buttons.tsx
+++ b/src/components/posts/post-buttons.tsx
@@ -248,15 +248,15 @@ export function PostVoting({
 
   const prefersDownvotes = scoreDisplayPreference === "downvotes";
   const prefersUpvotes = scoreDisplayPreference === "upvotes";
+  const prefersScore = scoreDisplayPreference === "score";
 
   // Heart mode — server has disabled downvotes.
   // Show count for score/upvotes modes; downvotes-only mode shows nothing
   // since the server doesn't support them.
-  if (!serverEnablesDownvotes) {
-    const showCount = scoreDisplayPreference === "score" || prefersUpvotes;
+  if (!serverEnablesDownvotes || scoreDisplayPreference === "none") {
     return (
       <Button
-        size={!showCount ? "icon" : "sm"}
+        size={prefersScore || prefersUpvotes ? "icon" : "sm"}
         variant={variant}
         onClick={() =>
           vote({
@@ -272,8 +272,8 @@ export function PostVoting({
         )}
       >
         {isUpvoted ? <FaHeart /> : <FaRegHeart />}
-        {showCount &&
-          abbriviateNumber(prefersUpvotes ? displayUpvotes : displayScore)}
+        {prefersScore && abbriviateNumber(displayScore)}
+        {prefersUpvotes && abbriviateNumber(displayUpvotes)}
       </Button>
     );
   }
@@ -291,19 +291,15 @@ export function PostVoting({
       ? `${displayUpvotes} upvotes`
       : `${displayUpvotes} upvotes, ${displayDownvotes} downvotes`;
 
-  const scoreNode = scoreDisplayPreference !== "none" && (
+  const scoreNode = (
     <Tooltip>
       <TooltipTrigger aria-label={tooltipText}>
         <label htmlFor={prefersDownvotes ? downvoteId : id}>
           <NumberFlow
             className={cn(
               "-mx-px cursor-pointer text-md",
-              prefersDownvotes
-                ? isDownvoted && "text-brand-secondary"
-                : cn(
-                    isUpvoted && "text-brand",
-                    isDownvoted && "text-brand-secondary",
-                  ),
+              isUpvoted && !prefersDownvotes && "text-brand",
+              isDownvoted && !prefersUpvotes && "text-brand-secondary",
             )}
             suffix={abbrv.suffix}
             value={abbrv.number}
@@ -349,7 +345,9 @@ export function PostVoting({
       </Button>
 
       {/* Separator left of score — only in downvotes mode */}
-      {prefersDownvotes && <Separator orientation="vertical" className="h-4" />}
+      {prefersDownvotes && (
+        <Separator orientation="vertical" className="min-h-4 mr-2.5" />
+      )}
 
       {scoreNode}
 

--- a/src/components/posts/post-buttons.tsx
+++ b/src/components/posts/post-buttons.tsx
@@ -40,15 +40,20 @@ import {
   useAddPostReactionEmojiMutation,
   useLikePostMutation,
 } from "@/src/queries/post-mutations";
-import { useShouldShowDownvotes, useScoreDisplay } from "@/src/stores/utils";
+import {
+  useServerEnablesDownvotes,
+  useScoreDisplayPreference,
+} from "@/src/stores/utils";
 import { Separator } from "../ui/separator";
 import { NumberFlow } from "../number-flow";
 import { MAX_REACTIONS } from "./config";
 import { downloadImage, shareImage } from "@/src/hooks/share";
 
 export function usePostVoting(post: Schemas.Post | undefined) {
-  const enableDownvotes = useShouldShowDownvotes("enablePostDownvotes");
-  const scoreDisplay = useScoreDisplay();
+  const serverEnablesDownvotes = useServerEnablesDownvotes(
+    "enablePostDownvotes",
+  );
+  const scoreDisplayPreference = useScoreDisplayPreference();
 
   const { mutate: mutateVote } = useLikePostMutation();
 
@@ -84,8 +89,8 @@ export function usePostVoting(post: Schemas.Post | undefined) {
     isUpvoted,
     isDownvoted,
     vote,
-    enableDownvotes,
-    scoreDisplay,
+    serverEnablesDownvotes,
+    scoreDisplayPreference,
     postId: post.id,
   };
 }
@@ -231,8 +236,8 @@ export function PostVoting({
     displayDownvotes,
     isUpvoted,
     isDownvoted,
-    enableDownvotes,
-    scoreDisplay,
+    serverEnablesDownvotes,
+    scoreDisplayPreference,
     vote,
     postId,
   } = voting;
@@ -241,11 +246,14 @@ export function PostVoting({
   const abbrvUpvotes = abbriviateNumberParts(displayUpvotes);
   const abbrvDownvotes = abbriviateNumberParts(-displayDownvotes);
 
+  const prefersDownvotes = scoreDisplayPreference === "downvotes";
+  const prefersUpvotes = scoreDisplayPreference === "upvotes";
+
   // Heart mode — server has disabled downvotes.
   // Show count for score/upvotes modes; downvotes-only mode shows nothing
   // since the server doesn't support them.
-  if (!enableDownvotes) {
-    const showCount = scoreDisplay === "score" || scoreDisplay === "upvotes";
+  if (!serverEnablesDownvotes) {
+    const showCount = scoreDisplayPreference === "score" || prefersUpvotes;
     return (
       <Button
         size={!showCount ? "icon" : "sm"}
@@ -265,35 +273,32 @@ export function PostVoting({
       >
         {isUpvoted ? <FaHeart /> : <FaRegHeart />}
         {showCount &&
-          abbriviateNumber(
-            scoreDisplay === "upvotes" ? displayUpvotes : displayScore,
-          )}
+          abbriviateNumber(prefersUpvotes ? displayUpvotes : displayScore)}
       </Button>
     );
   }
 
-  const isDownvoteSide = scoreDisplay === "downvotes";
   const downvoteId = `${id}-down`;
 
-  const abbrv = isDownvoteSide
+  const abbrv = prefersDownvotes
     ? abbrvDownvotes
-    : scoreDisplay === "upvotes"
+    : prefersUpvotes
       ? abbrvUpvotes
       : abbrvScore;
-  const tooltipText = isDownvoteSide
+  const tooltipText = prefersDownvotes
     ? `${displayDownvotes} downvotes`
-    : scoreDisplay === "upvotes"
+    : prefersUpvotes
       ? `${displayUpvotes} upvotes`
       : `${displayUpvotes} upvotes, ${displayDownvotes} downvotes`;
 
-  const scoreNode = scoreDisplay !== "none" && (
+  const scoreNode = scoreDisplayPreference !== "none" && (
     <Tooltip>
       <TooltipTrigger aria-label={tooltipText}>
-        <label htmlFor={isDownvoteSide ? downvoteId : id}>
+        <label htmlFor={prefersDownvotes ? downvoteId : id}>
           <NumberFlow
             className={cn(
               "-mx-px cursor-pointer text-md",
-              isDownvoteSide
+              prefersDownvotes
                 ? isDownvoted && "text-brand-secondary"
                 : cn(
                     isUpvoted && "text-brand",
@@ -344,13 +349,13 @@ export function PostVoting({
       </Button>
 
       {/* Separator left of score — only in downvotes mode */}
-      {isDownvoteSide && <Separator orientation="vertical" className="h-4" />}
+      {prefersDownvotes && <Separator orientation="vertical" className="h-4" />}
 
       {scoreNode}
 
       {/* Separator right of score — only in upvotes mode */}
-      {scoreDisplay === "upvotes" && (
-        <Separator orientation="vertical" className="h-4" />
+      {prefersUpvotes && (
+        <Separator orientation="vertical" className="min-h-4 ml-2.5" />
       )}
 
       <Button

--- a/src/components/posts/post-buttons.tsx
+++ b/src/components/posts/post-buttons.tsx
@@ -256,7 +256,7 @@ export function PostVoting({
   if (!serverEnablesDownvotes || scoreDisplayPreference === "none") {
     return (
       <Button
-        size={prefersScore || prefersUpvotes ? "icon" : "sm"}
+        size={prefersScore || prefersUpvotes ? "sm" : "icon"}
         variant={variant}
         onClick={() =>
           vote({

--- a/src/components/posts/post.tsx
+++ b/src/components/posts/post.tsx
@@ -221,16 +221,18 @@ function StickyPostScore({ post }: { post: Schemas.Post }) {
     return null;
   }
 
+  const prefersDownvotes = scoreDisplayPreference === "downvotes";
+  const prefersUpvotes = scoreDisplayPreference === "upvotes";
+
   // Heart mode — server has disabled downvotes. Mirror PostVoting:
   // show a count for "score"/"upvotes" modes; "downvotes" mode has nothing
   // meaningful to show since the server has no downvotes.
   if (!serverEnablesDownvotes) {
-    if (scoreDisplayPreference === "downvotes") {
+    if (prefersDownvotes) {
       return null;
     }
-    const votes =
-      scoreDisplayPreference === "upvotes" ? displayUpvotes : displayScore;
-    const label = scoreDisplayPreference === "upvotes" ? "upvotes" : "likes";
+    const votes = prefersUpvotes ? displayUpvotes : displayScore;
+    const label = prefersUpvotes ? "upvotes" : "likes";
     return (
       <span>
         {abbriviateNumber(votes)} {label}
@@ -238,10 +240,10 @@ function StickyPostScore({ post }: { post: Schemas.Post }) {
     );
   }
 
-  if (scoreDisplayPreference === "upvotes") {
+  if (prefersUpvotes) {
     return <span>{abbriviateNumber(displayUpvotes)} upvotes</span>;
   }
-  if (scoreDisplayPreference === "downvotes") {
+  if (prefersDownvotes) {
     return <span>{abbriviateNumber(displayDownvotes)} downvotes</span>;
   }
   return (

--- a/src/components/posts/post.tsx
+++ b/src/components/posts/post.tsx
@@ -266,11 +266,11 @@ export function StickyPostHeader({
   return (
     <div
       className={cn(
-        "md:hidden flex flex-row gap-3 bg-background border-b dark:border-t-[.5px] max-md:border-b-[.5px] opacity-0 [[data-is-sticky-header=true]_&]:opacity-100 max-md: max-md:px-3.5 absolute top-0 inset-x-0 transition-opacity",
+        "md:hidden flex flex-row gap-3 h-[58px] bg-background border-b dark:border-t-[.5px] max-md:border-b-[.5px] opacity-0 [[data-is-sticky-header=true]_&]:opacity-100 max-md: max-md:px-3.5 absolute top-0 inset-x-0 transition-opacity",
         showThumbnail && "max-md:pr-0",
       )}
     >
-      <div className="flex-1 my-2 flex flex-col justify-center overflow-hidden select-text min-w-0">
+      <div className="flex-1 my-2 flex flex-col justify-center gap-0.5 overflow-hidden select-text min-w-0">
         <div className="font-semibold truncate text-sm">
           {postView.deleted
             ? "deleted"

--- a/src/components/posts/post.tsx
+++ b/src/components/posts/post.tsx
@@ -18,7 +18,10 @@ import {
 } from "./post-buttons";
 import { resolveVoteCounts } from "@/src/lib/voting";
 import { abbriviateNumber } from "@/src/lib/format";
-import { useScoreDisplay, useShouldShowDownvotes } from "@/src/stores/utils";
+import {
+  useScoreDisplayPreference,
+  useServerEnablesDownvotes,
+} from "@/src/stores/utils";
 import { MarkdownRenderer } from "../markdown/renderer";
 import { twMerge } from "tailwind-merge";
 import { PostLoopsEmbed } from "./embeds/post-loops-embed";
@@ -207,35 +210,38 @@ function ExtraSmallPostCardSkeleton() {
 }
 
 function StickyPostScore({ post }: { post: Schemas.Post }) {
-  const enableDownvotes = useShouldShowDownvotes("enablePostDownvotes");
-  const scoreDisplay = useScoreDisplay();
+  const serverEnablesDownvotes = useServerEnablesDownvotes(
+    "enablePostDownvotes",
+  );
+  const scoreDisplayPreference = useScoreDisplayPreference();
   const { displayUpvotes, displayDownvotes, displayScore } =
     resolveVoteCounts(post);
 
-  if (scoreDisplay === "none") {
+  if (scoreDisplayPreference === "none") {
     return null;
   }
 
   // Heart mode — server has disabled downvotes. Mirror PostVoting:
   // show a count for "score"/"upvotes" modes; "downvotes" mode has nothing
   // meaningful to show since the server has no downvotes.
-  if (!enableDownvotes) {
-    if (scoreDisplay === "downvotes") {
+  if (!serverEnablesDownvotes) {
+    if (scoreDisplayPreference === "downvotes") {
       return null;
     }
-    const n = scoreDisplay === "upvotes" ? displayUpvotes : displayScore;
-    const label = scoreDisplay === "upvotes" ? "upvotes" : "likes";
+    const votes =
+      scoreDisplayPreference === "upvotes" ? displayUpvotes : displayScore;
+    const label = scoreDisplayPreference === "upvotes" ? "upvotes" : "likes";
     return (
       <span>
-        {abbriviateNumber(n)} {label}
+        {abbriviateNumber(votes)} {label}
       </span>
     );
   }
 
-  if (scoreDisplay === "upvotes") {
+  if (scoreDisplayPreference === "upvotes") {
     return <span>{abbriviateNumber(displayUpvotes)} upvotes</span>;
   }
-  if (scoreDisplay === "downvotes") {
+  if (scoreDisplayPreference === "downvotes") {
     return <span>{abbriviateNumber(displayDownvotes)} downvotes</span>;
   }
   return (

--- a/src/components/posts/post.tsx
+++ b/src/components/posts/post.tsx
@@ -16,6 +16,9 @@ import {
   PostVoting,
   useDoubleTapPostLike,
 } from "./post-buttons";
+import { resolveVoteCounts } from "@/src/lib/voting";
+import { abbriviateNumber } from "@/src/lib/format";
+import { useScoreDisplay, useShouldShowDownvotes } from "@/src/stores/utils";
 import { MarkdownRenderer } from "../markdown/renderer";
 import { twMerge } from "tailwind-merge";
 import { PostLoopsEmbed } from "./embeds/post-loops-embed";
@@ -203,6 +206,46 @@ function ExtraSmallPostCardSkeleton() {
   );
 }
 
+function StickyPostScore({ post }: { post: Schemas.Post }) {
+  const enableDownvotes = useShouldShowDownvotes("enablePostDownvotes");
+  const scoreDisplay = useScoreDisplay();
+  const { displayUpvotes, displayDownvotes, displayScore } =
+    resolveVoteCounts(post);
+
+  if (scoreDisplay === "none") {
+    return null;
+  }
+
+  // Heart mode — server has disabled downvotes. Mirror PostVoting:
+  // show a count for "score"/"upvotes" modes; "downvotes" mode has nothing
+  // meaningful to show since the server has no downvotes.
+  if (!enableDownvotes) {
+    if (scoreDisplay === "downvotes") {
+      return null;
+    }
+    const n = scoreDisplay === "upvotes" ? displayUpvotes : displayScore;
+    const label = scoreDisplay === "upvotes" ? "upvotes" : "likes";
+    return (
+      <span>
+        {abbriviateNumber(n)} {label}
+      </span>
+    );
+  }
+
+  if (scoreDisplay === "upvotes") {
+    return <span>{abbriviateNumber(displayUpvotes)} upvotes</span>;
+  }
+  if (scoreDisplay === "downvotes") {
+    return <span>{abbriviateNumber(displayDownvotes)} downvotes</span>;
+  }
+  return (
+    <span>
+      {abbriviateNumber(displayUpvotes)} upvotes &middot;{" "}
+      {abbriviateNumber(displayDownvotes)} downvotes
+    </span>
+  );
+}
+
 export function StickyPostHeader({
   apId,
 }: {
@@ -227,12 +270,17 @@ export function StickyPostHeader({
         showThumbnail && "max-md:pr-0",
       )}
     >
-      <div className="flex-1 my-2 font-semibold line-clamp-2 text-sm overflow-hidden select-text">
-        {postView.deleted
-          ? "deleted"
-          : postView.removed
-            ? "removed"
-            : postView.title}
+      <div className="flex-1 my-2 flex flex-col justify-center overflow-hidden select-text min-w-0">
+        <div className="font-semibold truncate text-sm">
+          {postView.deleted
+            ? "deleted"
+            : postView.removed
+              ? "removed"
+              : postView.title}
+        </div>
+        <div className="text-xs text-muted-foreground truncate">
+          <StickyPostScore post={postView} />
+        </div>
       </div>
       {showThumbnail && (
         <Link

--- a/src/stores/utils.test.ts
+++ b/src/stores/utils.test.ts
@@ -55,26 +55,14 @@ describe("scoreDisplayPreference — 'account' mode derives from site flags", ()
     const site = api.getSite({
       showUpvotes: true,
       showDownvotes: true,
-      enableCommentDownvotes: true,
     });
     expect(scoreDisplayPreference("account", site)).toBe("score");
-  });
-
-  // showDownvotes=true is ignored when the server has disabled downvotes.
-  test("showUpvotes=true, showDownvotes=true, enableCommentDownvotes=false → 'upvotes'", () => {
-    const site = api.getSite({
-      showUpvotes: true,
-      showDownvotes: true,
-      enableCommentDownvotes: false,
-    });
-    expect(scoreDisplayPreference("account", site)).toBe("upvotes");
   });
 
   test("showUpvotes=true, showDownvotes=false → 'upvotes'", () => {
     const site = api.getSite({
       showUpvotes: true,
       showDownvotes: false,
-      enableCommentDownvotes: true,
     });
     expect(scoreDisplayPreference("account", site)).toBe("upvotes");
   });
@@ -83,7 +71,6 @@ describe("scoreDisplayPreference — 'account' mode derives from site flags", ()
     const site = api.getSite({
       showUpvotes: false,
       showDownvotes: true,
-      enableCommentDownvotes: true,
     });
     expect(scoreDisplayPreference("account", site)).toBe("downvotes");
   });

--- a/src/stores/utils.test.ts
+++ b/src/stores/utils.test.ts
@@ -50,7 +50,7 @@ describe("scoreDisplayPreference — explicit app-level override", () => {
 
 describe("scoreDisplayPreference — 'account' mode derives from site flags", () => {
   // showUpvotes=true + showDownvotes=true → treated as combined score.
-  test("showUpvotes=true, showDownvotes=true, enableCommentDownvotes=true → 'score'", () => {
+  test("showUpvotes=true, showDownvotes=true → 'score'", () => {
     const site = api.getSite({
       showUpvotes: true,
       showDownvotes: true,
@@ -66,7 +66,7 @@ describe("scoreDisplayPreference — 'account' mode derives from site flags", ()
     expect(scoreDisplayPreference("account", site)).toBe("upvotes");
   });
 
-  test("showUpvotes=false, showDownvotes=true, enableCommentDownvotes=true → 'downvotes'", () => {
+  test("showUpvotes=false, showDownvotes=true → 'downvotes'", () => {
     const site = api.getSite({
       showUpvotes: false,
       showDownvotes: true,

--- a/src/stores/utils.test.ts
+++ b/src/stores/utils.test.ts
@@ -1,7 +1,6 @@
 import { describe, test, expect } from "vitest";
 import {
   scoreDisplayPreference,
-  canShowDownvotes,
   resolveThreshold,
   mergeCacheObject,
   mergeCacheArray,
@@ -97,60 +96,6 @@ describe("scoreDisplayPreference — 'account' mode derives from site flags", ()
   // No site (logged-out guest) — all flags default to true → 'score'.
   test("no site (logged out) defaults to 'score'", () => {
     expect(scoreDisplayPreference("account", undefined)).toBe("score");
-  });
-});
-
-// ─── canShowDownvotes ─────────────────────────────────────────────────────
-
-describe("canShowDownvotes — explicit 'none' always hides button", () => {
-  test("voteDisplaySetting='none' hides downvote button even when server enables them", () => {
-    expect(canShowDownvotes("none", true, "score")).toBe(false);
-  });
-});
-
-describe("canShowDownvotes — explicit app-level modes respect server capability", () => {
-  test("'score' + server enables downvotes → show button", () => {
-    expect(canShowDownvotes("score", true, "score")).toBe(true);
-  });
-
-  test("'score' + server disables downvotes → hide button", () => {
-    expect(canShowDownvotes("score", false, "score")).toBe(false);
-  });
-
-  test("'upvotes' + server enables downvotes → show button", () => {
-    expect(canShowDownvotes("upvotes", true, "upvotes")).toBe(true);
-  });
-
-  test("'downvotes' + server enables downvotes → show button", () => {
-    expect(canShowDownvotes("downvotes", true, "downvotes")).toBe(true);
-  });
-
-  test("'downvotes' + server disables downvotes → hide button", () => {
-    expect(canShowDownvotes("downvotes", false, "downvotes")).toBe(false);
-  });
-});
-
-describe("canShowDownvotes — 'account' mode", () => {
-  // Key regression: score mode has showDownvotes=false on the account object
-  // but the downvote button should still appear when the server supports it.
-  test("account scoreDisplay='score', server enables downvotes → show button", () => {
-    expect(canShowDownvotes("account", true, "score")).toBe(true);
-  });
-
-  test("account scoreDisplay='score', server disables downvotes → hide button", () => {
-    expect(canShowDownvotes("account", false, "score")).toBe(false);
-  });
-
-  test("account scoreDisplay='upvotes', server enables downvotes → show button", () => {
-    expect(canShowDownvotes("account", true, "upvotes")).toBe(true);
-  });
-
-  test("account scoreDisplay='downvotes', server enables downvotes → show button", () => {
-    expect(canShowDownvotes("account", true, "downvotes")).toBe(true);
-  });
-
-  test("account scoreDisplay='none' → hide button even when server enables them", () => {
-    expect(canShowDownvotes("account", true, "none")).toBe(false);
   });
 });
 

--- a/src/stores/utils.test.ts
+++ b/src/stores/utils.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect } from "vitest";
 import {
-  scoreDisplayFromSite,
-  shouldShowDownvotes,
+  scoreDisplayPreference,
+  canShowDownvotes,
   resolveThreshold,
   mergeCacheObject,
   mergeCacheArray,
@@ -9,16 +9,16 @@ import {
 import * as api from "@/test-utils/api";
 import z from "zod";
 
-// ─── scoreDisplayFromSite ────────────────────────────────────────────────────
+// ─── scoreDisplayPreference ────────────────────────────────────────────────────
 
-describe("scoreDisplayFromSite — explicit app-level override", () => {
+describe("scoreDisplayPreference — explicit app-level override", () => {
   test("'score' override always returns 'score'", () => {
     const site = api.getSite({
       showUpvotes: false,
       showDownvotes: false,
       showScores: false,
     });
-    expect(scoreDisplayFromSite("score", site)).toBe("score");
+    expect(scoreDisplayPreference("score", site)).toBe("score");
   });
 
   test("'upvotes' override always returns 'upvotes'", () => {
@@ -27,7 +27,7 @@ describe("scoreDisplayFromSite — explicit app-level override", () => {
       showDownvotes: false,
       showScores: false,
     });
-    expect(scoreDisplayFromSite("upvotes", site)).toBe("upvotes");
+    expect(scoreDisplayPreference("upvotes", site)).toBe("upvotes");
   });
 
   test("'downvotes' override always returns 'downvotes'", () => {
@@ -36,7 +36,7 @@ describe("scoreDisplayFromSite — explicit app-level override", () => {
       showDownvotes: false,
       showScores: false,
     });
-    expect(scoreDisplayFromSite("downvotes", site)).toBe("downvotes");
+    expect(scoreDisplayPreference("downvotes", site)).toBe("downvotes");
   });
 
   test("'none' override always returns 'none'", () => {
@@ -45,11 +45,11 @@ describe("scoreDisplayFromSite — explicit app-level override", () => {
       showDownvotes: true,
       showScores: true,
     });
-    expect(scoreDisplayFromSite("none", site)).toBe("none");
+    expect(scoreDisplayPreference("none", site)).toBe("none");
   });
 });
 
-describe("scoreDisplayFromSite — 'account' mode derives from site flags", () => {
+describe("scoreDisplayPreference — 'account' mode derives from site flags", () => {
   // showUpvotes=true + showDownvotes=true → treated as combined score.
   test("showUpvotes=true, showDownvotes=true, enableCommentDownvotes=true → 'score'", () => {
     const site = api.getSite({
@@ -57,7 +57,7 @@ describe("scoreDisplayFromSite — 'account' mode derives from site flags", () =
       showDownvotes: true,
       enableCommentDownvotes: true,
     });
-    expect(scoreDisplayFromSite("account", site)).toBe("score");
+    expect(scoreDisplayPreference("account", site)).toBe("score");
   });
 
   // showDownvotes=true is ignored when the server has disabled downvotes.
@@ -67,7 +67,7 @@ describe("scoreDisplayFromSite — 'account' mode derives from site flags", () =
       showDownvotes: true,
       enableCommentDownvotes: false,
     });
-    expect(scoreDisplayFromSite("account", site)).toBe("upvotes");
+    expect(scoreDisplayPreference("account", site)).toBe("upvotes");
   });
 
   test("showUpvotes=true, showDownvotes=false → 'upvotes'", () => {
@@ -76,7 +76,7 @@ describe("scoreDisplayFromSite — 'account' mode derives from site flags", () =
       showDownvotes: false,
       enableCommentDownvotes: true,
     });
-    expect(scoreDisplayFromSite("account", site)).toBe("upvotes");
+    expect(scoreDisplayPreference("account", site)).toBe("upvotes");
   });
 
   test("showUpvotes=false, showDownvotes=true, enableCommentDownvotes=true → 'downvotes'", () => {
@@ -85,7 +85,7 @@ describe("scoreDisplayFromSite — 'account' mode derives from site flags", () =
       showDownvotes: true,
       enableCommentDownvotes: true,
     });
-    expect(scoreDisplayFromSite("account", site)).toBe("downvotes");
+    expect(scoreDisplayPreference("account", site)).toBe("downvotes");
   });
 
   // showScores=true acts as a fallback combined score when individual flags are off.
@@ -95,7 +95,7 @@ describe("scoreDisplayFromSite — 'account' mode derives from site flags", () =
       showDownvotes: false,
       showScores: true,
     });
-    expect(scoreDisplayFromSite("account", site)).toBe("score");
+    expect(scoreDisplayPreference("account", site)).toBe("score");
   });
 
   test("showUpvotes=false, showDownvotes=false, showScores=false → 'none'", () => {
@@ -104,66 +104,66 @@ describe("scoreDisplayFromSite — 'account' mode derives from site flags", () =
       showDownvotes: false,
       showScores: false,
     });
-    expect(scoreDisplayFromSite("account", site)).toBe("none");
+    expect(scoreDisplayPreference("account", site)).toBe("none");
   });
 
   // No site (logged-out guest) — all flags default to true → 'score'.
   test("no site (logged out) defaults to 'score'", () => {
-    expect(scoreDisplayFromSite("account", undefined)).toBe("score");
+    expect(scoreDisplayPreference("account", undefined)).toBe("score");
   });
 });
 
-// ─── shouldShowDownvotes ─────────────────────────────────────────────────────
+// ─── canShowDownvotes ─────────────────────────────────────────────────────
 
-describe("shouldShowDownvotes — explicit 'none' always hides button", () => {
+describe("canShowDownvotes — explicit 'none' always hides button", () => {
   test("voteDisplaySetting='none' hides downvote button even when server enables them", () => {
-    expect(shouldShowDownvotes("none", true, "score")).toBe(false);
+    expect(canShowDownvotes("none", true, "score")).toBe(false);
   });
 });
 
-describe("shouldShowDownvotes — explicit app-level modes respect server capability", () => {
+describe("canShowDownvotes — explicit app-level modes respect server capability", () => {
   test("'score' + server enables downvotes → show button", () => {
-    expect(shouldShowDownvotes("score", true, "score")).toBe(true);
+    expect(canShowDownvotes("score", true, "score")).toBe(true);
   });
 
   test("'score' + server disables downvotes → hide button", () => {
-    expect(shouldShowDownvotes("score", false, "score")).toBe(false);
+    expect(canShowDownvotes("score", false, "score")).toBe(false);
   });
 
   test("'upvotes' + server enables downvotes → show button", () => {
-    expect(shouldShowDownvotes("upvotes", true, "upvotes")).toBe(true);
+    expect(canShowDownvotes("upvotes", true, "upvotes")).toBe(true);
   });
 
   test("'downvotes' + server enables downvotes → show button", () => {
-    expect(shouldShowDownvotes("downvotes", true, "downvotes")).toBe(true);
+    expect(canShowDownvotes("downvotes", true, "downvotes")).toBe(true);
   });
 
   test("'downvotes' + server disables downvotes → hide button", () => {
-    expect(shouldShowDownvotes("downvotes", false, "downvotes")).toBe(false);
+    expect(canShowDownvotes("downvotes", false, "downvotes")).toBe(false);
   });
 });
 
-describe("shouldShowDownvotes — 'account' mode", () => {
+describe("canShowDownvotes — 'account' mode", () => {
   // Key regression: score mode has showDownvotes=false on the account object
   // but the downvote button should still appear when the server supports it.
   test("account scoreDisplay='score', server enables downvotes → show button", () => {
-    expect(shouldShowDownvotes("account", true, "score")).toBe(true);
+    expect(canShowDownvotes("account", true, "score")).toBe(true);
   });
 
   test("account scoreDisplay='score', server disables downvotes → hide button", () => {
-    expect(shouldShowDownvotes("account", false, "score")).toBe(false);
+    expect(canShowDownvotes("account", false, "score")).toBe(false);
   });
 
   test("account scoreDisplay='upvotes', server enables downvotes → show button", () => {
-    expect(shouldShowDownvotes("account", true, "upvotes")).toBe(true);
+    expect(canShowDownvotes("account", true, "upvotes")).toBe(true);
   });
 
   test("account scoreDisplay='downvotes', server enables downvotes → show button", () => {
-    expect(shouldShowDownvotes("account", true, "downvotes")).toBe(true);
+    expect(canShowDownvotes("account", true, "downvotes")).toBe(true);
   });
 
   test("account scoreDisplay='none' → hide button even when server enables them", () => {
-    expect(shouldShowDownvotes("account", true, "none")).toBe(false);
+    expect(canShowDownvotes("account", true, "none")).toBe(false);
   });
 });
 

--- a/src/stores/utils.ts
+++ b/src/stores/utils.ts
@@ -92,10 +92,8 @@ export function scoreDisplayPreference(
   // When both showUpvotes and showDownvotes are enabled Lemmy ignores
   // showScores and shows separate counts; we treat that as combined score
   // since the visual result is equivalent.
-  const serverEnablesDownvotes = site?.enableCommentDownvotes ?? true;
   const showUpvotes = site?.showUpvotes ?? true;
-  // Treat showDownvotes as false when the server has disabled downvotes entirely.
-  const showDownvotes = (site?.showDownvotes ?? true) && serverEnablesDownvotes;
+  const showDownvotes = site?.showDownvotes ?? true;
   const showScores = site?.showScores ?? true;
 
   if (showUpvotes && showDownvotes) {

--- a/src/stores/utils.ts
+++ b/src/stores/utils.ts
@@ -75,12 +75,17 @@ export function mergeCacheArray<TSchema extends z.ZodType>(
   return [...aItems, ...bItems];
 }
 
-export function scoreDisplayFromSite(
-  voteDisplaySetting: VoteDisplaySetting,
+/**
+ * Resolve user score preference with what the server allows
+ *
+ * Exported for testing
+ */
+export function scoreDisplayPreference(
+  voteDisplayAppSetting: VoteDisplaySetting,
   site: Schemas.Site | undefined,
 ): ScoreDisplay {
-  if (voteDisplaySetting !== "account") {
-    return voteDisplaySetting;
+  if (voteDisplayAppSetting !== "account") {
+    return voteDisplayAppSetting;
   }
 
   // "account" mode — derive from account/server settings.
@@ -108,22 +113,22 @@ export function scoreDisplayFromSite(
   return "none";
 }
 
-export function shouldShowDownvotes(
-  voteDisplaySetting: VoteDisplaySetting,
-  serverCapability: boolean,
+export function canShowDownvotes(
+  voteDisplayAppSetting: VoteDisplaySetting,
+  serverAllowsDownvotes: boolean,
   scoreDisplay: ScoreDisplay,
 ): boolean {
-  if (voteDisplaySetting === "none") {
+  if (voteDisplayAppSetting === "none") {
     return false;
   }
-  if (voteDisplaySetting === "account") {
+  if (voteDisplayAppSetting === "account") {
     // Use the resolved display mode rather than site.showDownvotes directly.
     // e.g. "score" mode has showDownvotes=false on the account but the
     // downvote button should still appear when the server supports it.
-    return scoreDisplay !== "none" && serverCapability;
+    return scoreDisplay !== "none" && serverAllowsDownvotes;
   }
   // Any explicit display mode still shows the downvote button if the server allows it.
-  return serverCapability;
+  return serverAllowsDownvotes;
 }
 
 export function resolveThreshold(
@@ -138,26 +143,20 @@ export function resolveThreshold(
 
 // ─── Hooks ───────────────────────────────────────────────────────────────────
 
-export function useScoreDisplay(): ScoreDisplay {
+export function useScoreDisplayPreference(): ScoreDisplay {
   const voteDisplaySetting = useSettingsStore((s) => s.voteDisplaySetting);
   const site = useAuth((s) => getAccountSite(s.getSelectedAccount()));
-  return scoreDisplayFromSite(voteDisplaySetting, site);
+  return scoreDisplayPreference(voteDisplaySetting, site);
 }
 
-export function useShouldShowDownvotes(
+export function useServerEnablesDownvotes(
   serverCapabilityKey: "enablePostDownvotes" | "enableCommentDownvotes",
 ): boolean {
-  const voteDisplaySetting = useSettingsStore((s) => s.voteDisplaySetting);
-  const serverCapability =
+  const serverAllowsDownvotes =
     useAuth(
       (s) => getAccountSite(s.getSelectedAccount())?.[serverCapabilityKey],
     ) ?? true;
-  const scoreDisplay = useScoreDisplay();
-  return shouldShowDownvotes(
-    voteDisplaySetting,
-    serverCapability,
-    scoreDisplay,
-  );
+  return serverAllowsDownvotes;
 }
 
 export function useCommentCollapseThreshold(): number | null {

--- a/src/stores/utils.ts
+++ b/src/stores/utils.ts
@@ -111,24 +111,6 @@ export function scoreDisplayPreference(
   return "none";
 }
 
-export function canShowDownvotes(
-  voteDisplayAppSetting: VoteDisplaySetting,
-  serverAllowsDownvotes: boolean,
-  scoreDisplay: ScoreDisplay,
-): boolean {
-  if (voteDisplayAppSetting === "none") {
-    return false;
-  }
-  if (voteDisplayAppSetting === "account") {
-    // Use the resolved display mode rather than site.showDownvotes directly.
-    // e.g. "score" mode has showDownvotes=false on the account but the
-    // downvote button should still appear when the server supports it.
-    return scoreDisplay !== "none" && serverAllowsDownvotes;
-  }
-  // Any explicit display mode still shows the downvote button if the server allows it.
-  return serverAllowsDownvotes;
-}
-
 export function resolveThreshold(
   setting: ThresholdSetting,
   accountThreshold: number | undefined,


### PR DESCRIPTION
Title in the mobile sticky post header now truncates at 1 line. A
subtitle below shows vote counts following the user's resolved
ScoreDisplay setting (none/score/upvotes/downvotes), and falls back to
likes in heart mode when the server has disabled downvotes.